### PR TITLE
Friendly academic UI redesign

### DIFF
--- a/angular-src/.angular-cli.json
+++ b/angular-src/.angular-cli.json
@@ -19,6 +19,7 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
+        "../node_modules/ngx-toastr/toastr.css",
         "styles.css"
       ],
       "scripts": [],

--- a/angular-src/package-lock.json
+++ b/angular-src/package-lock.json
@@ -424,11 +424,6 @@
       "dev": true,
       "optional": true
     },
-    "angular2-flash-messages": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/angular2-flash-messages/-/angular2-flash-messages-1.0.8.tgz",
-      "integrity": "sha512-UCGoBy2h3UkV9K4otRK2QgeIo0B6x1hM9jRnIjsY1KzTeJkH0Sdt6sMJm+B+NgGMhOVC86ZrtANNayY07cAqsw=="
-    },
     "angular2-jwt": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/angular2-jwt/-/angular2-jwt-0.2.3.tgz",
@@ -6192,6 +6187,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ngx-notify/-/ngx-notify-1.0.2.tgz",
       "integrity": "sha512-NyxA4mC2mwb3E8Nx+BagoWlEckOnvAqNO3DEQXOCinAzySnMShhXTlcx5h9eF31Ml6wD7eoeo/pR6JmRzZhppQ=="
+    },
+    "ngx-toastr": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-8.4.0.tgz",
+      "integrity": "sha512-vYNcOsMn76900tqnojvkMI/T7rqXN5e2OuWwcB6UOSO0S5QeHvIAKQI9ZbyHyW+2e08mW8gT7hbrii+Jy0umFw==",
+      "requires": {
+        "tslib": "^1.7.1"
+      }
     },
     "no-case": {
       "version": "2.3.2",

--- a/angular-src/package.json
+++ b/angular-src/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/angular-src/package.json
+++ b/angular-src/package.json
@@ -22,7 +22,6 @@
     "@angular/platform-browser-dynamic": "^5.2.6",
     "@angular/router": "^5.2.6",
     "@ng-bootstrap/ng-bootstrap": "^1.0.0",
-    "angular2-flash-messages": "^1.0.8",
     "angular2-jwt": "^0.2.3",
     "chart.js": "^2.7.0",
     "core-js": "^2.5.3",
@@ -34,6 +33,7 @@
     "ng2-smart-table": "^1.2.2",
     "ng4-loading-spinner": "^1.1.1",
     "ngx-countdown": "^2.0.4",
+    "ngx-toastr": "^8.4.0",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.20"
   },

--- a/angular-src/proxy.conf.json
+++ b/angular-src/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/User": { "target": "http://localhost:3050", "secure": false },
+  "/VHS": { "target": "http://localhost:3050", "secure": false },
+  "/VanHilleQuiz": { "target": "http://localhost:3050", "secure": false },
+  "/CloudLinks": { "target": "http://localhost:3050", "secure": false }
+}

--- a/angular-src/src/app/app.component.css
+++ b/angular-src/src/app/app.component.css
@@ -1,5 +1,6 @@
 .margin {
   margin-top: 60px;
+  padding: 0;
 }
 
 @media (min-width: 768px) {

--- a/angular-src/src/app/app.component.css
+++ b/angular-src/src/app/app.component.css
@@ -2,6 +2,12 @@
   margin-top: 60px;
 }
 
+@media (min-width: 768px) {
+  .margin {
+    padding-right: 220px;
+  }
+}
+
 .backimg {
   background-image: url("../assets/background.jpg");
   /*background-repeat: no-repeat;*/

--- a/angular-src/src/app/app.component.css
+++ b/angular-src/src/app/app.component.css
@@ -1,5 +1,5 @@
 .margin {
-  margin-top: 50px;
+  margin-top: 60px;
 }
 
 .backimg {

--- a/angular-src/src/app/app.component.html
+++ b/angular-src/src/app/app.component.html
@@ -1,5 +1,5 @@
 <app-navbar></app-navbar>
-<div class="container-fluid margin" style="padding: 0">
+<div class="container-fluid margin">
   <flash-messages></flash-messages>
   <router-outlet></router-outlet>
   <ng4-loading-spinner></ng4-loading-spinner>

--- a/angular-src/src/app/app.component.html
+++ b/angular-src/src/app/app.component.html
@@ -1,6 +1,5 @@
 <app-navbar></app-navbar>
 <div class="container-fluid margin">
-  <flash-messages></flash-messages>
   <router-outlet></router-outlet>
   <ng4-loading-spinner></ng4-loading-spinner>
 </div>

--- a/angular-src/src/app/app.component.html
+++ b/angular-src/src/app/app.component.html
@@ -1,5 +1,5 @@
 <app-navbar></app-navbar>
-<div class="container margin">
+<div class="container-fluid margin" style="padding: 0">
   <flash-messages></flash-messages>
   <router-outlet></router-outlet>
   <ng4-loading-spinner></ng4-loading-spinner>

--- a/angular-src/src/app/app.module.ts
+++ b/angular-src/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import {BrowserModule} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {FormsModule} from '@angular/forms';
@@ -17,7 +18,7 @@ import {VanhileformComponent} from './vanhillequiz/vanhileform/vanhileform.compo
 import {ReportComponent} from './vanhillequiz/report/report.component';
 //external modules
 import {ChartsModule} from 'ng2-charts/ng2-charts';
-import {FlashMessagesModule} from "angular2-flash-messages";
+import {ToastrModule} from 'ngx-toastr';
 import {Ng2SmartTableModule} from 'ng2-smart-table';
 import {Ng4LoadingSpinnerModule} from 'ng4-loading-spinner';
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
@@ -31,7 +32,7 @@ import {AuthService} from "./services/auth.service";
 import {SiteRegisterServiceService} from "./services/site-register-service.service";
 import {CloudlinksService} from "./services/cloudlinks.service"
 import {HttpErrorInterceptor} from "./services/http-error-interceptor.service";
-import {FlashMessagesService} from "angular2-flash-messages";
+import {ToastrService} from "ngx-toastr";
 import {StudentReportComponent} from './vanhillequiz/report/student-report/student-report.component';
 import {ClassReportComponent} from './vanhillequiz/report/class-report/class-report.component';
 import {TimerComponent} from './vanhillequiz/timer/timer.component';
@@ -94,12 +95,17 @@ const appRoutes: Routes = [
   entryComponents: [CustomEditorComponent],
   imports: [
     BrowserModule,
-    FlashMessagesModule,
-    BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     HttpModule,
     RouterModule.forRoot(appRoutes),
-    FlashMessagesModule,
+    ToastrModule.forRoot({
+      positionClass: 'toast-top-left',
+      timeOut: 3000,
+      closeButton: true,
+      progressBar: true,
+      preventDuplicates: true
+    }),
     ChartsModule,
     Ng4LoadingSpinnerModule.forRoot(),
     Ng2SmartTableModule,
@@ -117,9 +123,9 @@ const appRoutes: Routes = [
     CloudlinksService,
     {
       provide: Http,
-      useFactory: (backend: XHRBackend, options: RequestOptions, flashMessages: FlashMessagesService) =>
-        new HttpErrorInterceptor(backend, options, flashMessages),
-      deps: [XHRBackend, RequestOptions, FlashMessagesService]
+      useFactory: (backend: XHRBackend, options: RequestOptions, toastr: ToastrService) =>
+        new HttpErrorInterceptor(backend, options, toastr),
+      deps: [XHRBackend, RequestOptions, ToastrService]
     }
   ],
   bootstrap: [AppComponent]

--- a/angular-src/src/app/app.module.ts
+++ b/angular-src/src/app/app.module.ts
@@ -2,7 +2,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {FormsModule} from '@angular/forms';
-import {HttpModule} from '@angular/http';
+import {Http, HttpModule, RequestOptions, XHRBackend} from '@angular/http';
 
 //components
 import {AppComponent} from './app.component';
@@ -30,6 +30,8 @@ import {VanhilereportService} from "./services/vanhilereport.service";
 import {AuthService} from "./services/auth.service";
 import {SiteRegisterServiceService} from "./services/site-register-service.service";
 import {CloudlinksService} from "./services/cloudlinks.service"
+import {HttpErrorInterceptor} from "./services/http-error-interceptor.service";
+import {FlashMessagesService} from "angular2-flash-messages";
 import {StudentReportComponent} from './vanhillequiz/report/student-report/student-report.component';
 import {ClassReportComponent} from './vanhillequiz/report/class-report/class-report.component';
 import {TimerComponent} from './vanhillequiz/timer/timer.component';
@@ -112,7 +114,13 @@ const appRoutes: Routes = [
     VanhilereportService,
     AuthService,
     SiteRegisterServiceService,
-    CloudlinksService
+    CloudlinksService,
+    {
+      provide: Http,
+      useFactory: (backend: XHRBackend, options: RequestOptions, flashMessages: FlashMessagesService) =>
+        new HttpErrorInterceptor(backend, options, flashMessages),
+      deps: [XHRBackend, RequestOptions, FlashMessagesService]
+    }
   ],
   bootstrap: [AppComponent]
 })

--- a/angular-src/src/app/cloudlinks/cloudlinks.component.css
+++ b/angular-src/src/app/cloudlinks/cloudlinks.component.css
@@ -1,5 +1,72 @@
-.margin{
-    margin-top: 20px;
-    margin-right: 245px;
+/* Page header */
+#tbls {
+  padding: 0;
+  margin-bottom: 0;
 }
 
+.cloudlinks-hero {
+  background: linear-gradient(135deg, #5B7FFF 0%, #38C172 100%);
+  border-radius: 0 0 32px 32px;
+  padding: 48px 32px 32px;
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.cloudlinks-hero h2 {
+  color: #FFFFFF;
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-decoration: none !important;
+  margin: 0;
+}
+
+/* Table section */
+.table-section {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.table-section h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-decoration: none !important;
+  margin-bottom: 16px;
+  padding-right: 12px;
+  border-right: 4px solid #5B7FFF;
+}
+
+/* Admin action buttons */
+.admin-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 0 24px 24px;
+}
+
+/* ng2-smart-table overrides */
+ng2-smart-table ::ng-deep table {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+ng2-smart-table ::ng-deep .ng2-smart-actions a.ng2-smart-action-edit-edit,
+ng2-smart-table ::ng-deep .ng2-smart-actions a.ng2-smart-action-add-save {
+  color: #5B7FFF;
+  font-weight: 500;
+}
+
+ng2-smart-table ::ng-deep .ng2-smart-actions a.ng2-smart-action-delete-delete {
+  color: #EF4444;
+  font-weight: 500;
+}
+
+ng2-smart-table ::ng-deep thead tr th {
+  background-color: #F7F8FD;
+  color: #6B7280;
+  font-weight: 600;
+  font-size: 0.875rem;
+}

--- a/angular-src/src/app/cloudlinks/cloudlinks.component.css
+++ b/angular-src/src/app/cloudlinks/cloudlinks.component.css
@@ -70,3 +70,11 @@ ng2-smart-table ::ng-deep thead tr th {
   font-weight: 600;
   font-size: 0.875rem;
 }
+
+@media (max-width: 767px) {
+  .cloudlinks-hero { padding: 32px 16px 24px; }
+  .admin-actions { flex-direction: column; padding: 0 16px 16px; }
+  .admin-actions .btn { width: 100%; }
+  [style*="padding: 0 24px"] { padding: 0 12px !important; }
+  .table-section { padding: 16px; }
+}

--- a/angular-src/src/app/cloudlinks/cloudlinks.component.html
+++ b/angular-src/src/app/cloudlinks/cloudlinks.component.html
@@ -1,72 +1,66 @@
-<div id="tbls" class="jumbotron text-center margin">
-  <h2 dir="rtl" style="text-decoration: underline">קישורים לענן</h2>
-  <div *ngIf="tables_array != undefined">
-    <div *ngFor="let table of tables_array;let i = index">
-      <h3 style="text-decoration: underline">{{table.tableId}}</h3>
-      <ng2-smart-table [settings]="table.settings_obj" [source]="table.data" (createConfirm)="onCreateConfirm($event,this.tables_array[i])"
-                       (editConfirm)="onEditConfirm($event,this.tables_array[i])" (deleteConfirm)="onDeleteConfirm($event,this.tables_array[i])" style="font-size: 15px"></ng2-smart-table>
-    </div>
+<div class="cloudlinks-hero" dir="rtl">
+  <h2>קישורים לענן</h2>
+</div>
+
+<div style="padding: 0 24px" *ngIf="tables_array != undefined">
+  <div class="table-section" *ngFor="let table of tables_array;let i = index" dir="rtl">
+    <h3>{{table.tableId}}</h3>
+    <ng2-smart-table [settings]="table.settings_obj" [source]="table.data"
+                     (createConfirm)="onCreateConfirm($event,this.tables_array[i])"
+                     (editConfirm)="onEditConfirm($event,this.tables_array[i])"
+                     (deleteConfirm)="onDeleteConfirm($event,this.tables_array[i])"
+                     style="font-size: 15px">
+    </ng2-smart-table>
   </div>
 </div>
-<div class="btn-group col-md-offset-7" *ngIf="auth_service.loggedIn()">
-  <button class="btn btn-danger" data-toggle="modal" data-target="#deleteTableFormModal">Delete A Table
-  </button>
-  <button class="btn btn-success" data-toggle="modal" data-target="#addTableFormModal">Add A Table
-  </button>
+
+<div class="admin-actions" *ngIf="auth_service.loggedIn()">
+  <button class="btn btn-danger" data-toggle="modal" data-target="#deleteTableFormModal">מחק טבלה</button>
+  <button class="btn btn-success" data-toggle="modal" data-target="#addTableFormModal">הוסף טבלה</button>
 </div>
 
 <div class="modal fade" id="addTableFormModal" role="dialog">
   <div class="modal-dialog">
-
-    <!-- Modal Add Table content-->
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title text-center">Add A Table Form</h4>
+        <h4 class="modal-title text-center">הוספת טבלה</h4>
       </div>
       <div class="modal-body">
         <form>
           <div class="form-group">
-            <label for="tableHeader">Table Header Name:</label>
-            <input type="text" id="tableHeader" class="form-control" placeholder="Enter A Table Header"
+            <label for="tableHeader">שם הטבלה:</label>
+            <input type="text" id="tableHeader" class="form-control" placeholder="הכנס שם טבלה"
                    [(ngModel)]="tableName" name="tableName">
           </div>
         </form>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-dismiss="modal" (click)="addTable()">Add</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal" (click)="addTable()">הוסף</button>
       </div>
     </div>
-
   </div>
 </div>
 
 <div class="modal fade" id="deleteTableFormModal" role="dialog">
   <div class="modal-dialog">
-
-    <!-- Modal Add Table content-->
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title text-center">Delete A Table Form</h4>
+        <h4 class="modal-title text-center">מחיקת טבלה</h4>
       </div>
       <div class="modal-body">
         <form>
           <div class="form-group">
-            <label for="tableHeaderToDelete">Table Header Name:</label>
-            <input type="text" id="tableHeaderToDelete" class="form-control" placeholder="Enter A Table Header"
+            <label for="tableHeaderToDelete">שם הטבלה למחיקה:</label>
+            <input type="text" id="tableHeaderToDelete" class="form-control" placeholder="הכנס שם טבלה"
                    [(ngModel)]="tableName" name="tableName">
           </div>
         </form>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-dismiss="modal" (click)="deleteTable()">Delete</button>
+        <button type="button" class="btn btn-danger" data-dismiss="modal" (click)="deleteTable()">מחק</button>
       </div>
     </div>
-
   </div>
 </div>
-<!-- <p dir="rtl">
-  קישורים לענן יגיעו בהמשך!
-</p> -->
-<!-- https://github.com/akveo/ng2-smart-table -->

--- a/angular-src/src/app/cloudlinks/cloudlinks.component.ts
+++ b/angular-src/src/app/cloudlinks/cloudlinks.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 // import {Ng2SmartTableModule} from 'ng2-smart-table';
 import {AuthService} from '../services/auth.service';
 import {CloudlinksService} from '../services/cloudlinks.service';
-import {FlashMessagesService} from 'angular2-flash-messages';
+import {ToastrService} from 'ngx-toastr';
 import {CustomEditorComponent} from './custom-editor/custom-editor.component';
 
 
@@ -19,14 +19,14 @@ export class CloudlinksComponent implements OnInit {
 
   constructor(
     private  cloud_links_service: CloudlinksService,
-    private flashmessage: FlashMessagesService,
+    private toastr: ToastrService,
     private auth_service: AuthService) {
   }
 
   ngOnInit() {
     this.cloud_links_service.getAllCloudLinkTables().subscribe(tables => {
       if (!tables.success) {
-        this.flashmessage.show(tables.msg, {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error(tables.msg);
       } else {
         if (this.auth_service.loggedIn()) {
           this.tables_array = tables.cloudLinksTables;
@@ -105,12 +105,9 @@ export class CloudlinksComponent implements OnInit {
       data: []
     }).subscribe(data => {
       if (!data.success) {
-        this.flashmessage.show(JSON.stringify(data.msg), {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error(JSON.stringify(data.msg));
       } else {
-        this.flashmessage.show('Table ' + JSON.stringify(data.cloudLinkTable.tableId) + ' Was Created ', {
-          cssClass: 'alert-success',
-          timeout: 3000
-        });
+        this.toastr.success('Table ' + JSON.stringify(data.cloudLinkTable.tableId) + ' Was Created ');
       }
     });
   }
@@ -119,12 +116,9 @@ export class CloudlinksComponent implements OnInit {
     if (window.confirm('Are you sure you want to create?')) {
       this.cloud_links_service.addEntryToCloudLinkTable(tableId.tableId, event.newData).subscribe(data => {
         if (!data.err) {
-          this.flashmessage.show('new Entry was added to the table ' + tableId.tableId, {
-            cssClass: 'alert-success',
-            timeout: 3000
-          });
+          this.toastr.success('new Entry was added to the table ' + tableId.tableId);
         } else {
-          this.flashmessage.show('Something Went Wrong', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('Something Went Wrong');
         }
       });
       event.confirm.resolve(event.newData);
@@ -138,16 +132,13 @@ export class CloudlinksComponent implements OnInit {
     if (window.confirm('Are you sure you want to save?')) {
       this.cloud_links_service.deleteEntryFromCloudTable(tableId.tableId, event.data).subscribe(data => {
         if (!data.success) {
-          this.flashmessage.show('Something Went Wrong on update delete', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('Something Went Wrong on update delete');
         } else {
           this.cloud_links_service.addEntryToCloudLinkTable(tableId.tableId, event.newData).subscribe(data => {
             if (!data.success) {
-              this.flashmessage.show('Something Went Wrong on update add', {cssClass: 'alert-danger', timeout: 3000});
+              this.toastr.error('Something Went Wrong on update add');
             } else {
-              this.flashmessage.show('An Entry was updated in the table ' + tableId.tableId, {
-                cssClass: 'alert-success',
-                timeout: 3000
-              });
+              this.toastr.success('An Entry was updated in the table ' + tableId.tableId);
             }
           });
         }
@@ -162,12 +153,9 @@ export class CloudlinksComponent implements OnInit {
     if (window.confirm('Are you sure you want to delete?')) {
       this.cloud_links_service.deleteEntryFromCloudTable(tableId.tableId, event.data).subscribe(data => {
         if (!data.err) {
-          this.flashmessage.show('A row was successfully deleted from the table ' + tableId.tableId, {
-            cssClass: 'alert-success',
-            timeout: 3000
-          });
+          this.toastr.success('A row was successfully deleted from the table ' + tableId.tableId);
         } else {
-          this.flashmessage.show('Something Went Wrong', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('Something Went Wrong');
         }
       });
       event.confirm.resolve();
@@ -182,12 +170,9 @@ export class CloudlinksComponent implements OnInit {
         this.tables_array.splice(index, 1);
         this.cloud_links_service.deleteCloudLinkTable(this.tableName).subscribe(table => {
           if (!table.success) {
-            this.flashmessage.show(table.msg, {cssClass: 'alert-danger', timeout: 3000});
+            this.toastr.error(table.msg);
           } else {
-            this.flashmessage.show('Table ' + this.tableName + ' was deleted', {
-              cssClass: 'alert-success',
-              timeout: 3000
-            });
+            this.toastr.success('Table ' + this.tableName + ' was deleted');
           }
         });
       }

--- a/angular-src/src/app/home/home.component.css
+++ b/angular-src/src/app/home/home.component.css
@@ -68,3 +68,18 @@
 .home-card--blue   { border-top-color: #5B7FFF; }
 .home-card--green  { border-top-color: #38C172; }
 .home-card--orange { border-top-color: #FF8C42; }
+
+@media (max-width: 767px) {
+  .home-hero {
+    padding: 48px 24px;
+    border-radius: 0 0 24px 24px;
+    margin-bottom: 24px;
+  }
+  .home-hero h1 { font-size: 1.7rem; }
+  .home-cards {
+    flex-direction: column;
+    padding: 0 16px 32px;
+    gap: 16px;
+  }
+  .home-card { min-width: unset; }
+}

--- a/angular-src/src/app/home/home.component.css
+++ b/angular-src/src/app/home/home.component.css
@@ -1,4 +1,70 @@
-.margin{
-    margin-top: 50px;
-    margin-right: 245px;
+/* Hero */
+.home-hero {
+  background: linear-gradient(135deg, #5B7FFF 0%, #38C172 100%);
+  border-radius: 0 0 40px 40px;
+  padding: 80px 48px;
+  text-align: center;
+  margin-bottom: 48px;
 }
+
+.home-hero h1 {
+  color: #FFFFFF;
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.hero-subtitle {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 1.15rem;
+  font-weight: 400;
+  margin-bottom: 8px;
+}
+
+.hero-sub {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  margin-bottom: 0;
+}
+
+/* Cards row */
+.home-cards {
+  display: flex;
+  gap: 24px;
+  padding: 0 48px 48px;
+  flex-wrap: wrap;
+}
+
+.home-card {
+  flex: 1;
+  min-width: 220px;
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 32px 24px;
+  border-top: 4px solid transparent;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.home-card:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  transform: translateY(-2px);
+}
+
+.home-card h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #1F2937;
+}
+
+.home-card p {
+  font-size: 0.95rem;
+  color: #6B7280;
+  line-height: 1.7;
+  margin-bottom: 0;
+}
+
+.home-card--blue   { border-top-color: #5B7FFF; }
+.home-card--green  { border-top-color: #38C172; }
+.home-card--orange { border-top-color: #FF8C42; }

--- a/angular-src/src/app/home/home.component.html
+++ b/angular-src/src/app/home/home.component.html
@@ -1,23 +1,23 @@
 <div class="home-hero" dir="rtl">
-  <h1>מתמטיקה - למידה ומחקר</h1>
-  <p class="hero-subtitle">ברוכים הבאים לאתר מתמטיקה - למידה ומחקר</p>
-  <p class="hero-sub">לימינכם האופציות הקיימות</p>
+  <h1>זווית - למידה ומחקר במתמטיקה</h1>
+  <p class="hero-subtitle">כלים, מחקר ותרגול להוראת גיאומטריה מבוססת מודל ואן־הילה</p>
+  <p class="hero-sub">גלו את הכלים העומדים לרשותכם</p>
 </div>
 
 <div class="home-cards" dir="rtl">
   <div class="home-card home-card--blue">
-    <h3>כותרת 1</h3>
-    <p>Proident est excepteur esse non voluptate do anim est. Velit do amet laborum ea consequat nulla. Proident quis aliqua
-      laborum laboris elit enim consectetur nisi ad. Reprehenderit in proident eiusmod consequat et labore.</p>
+    <h3>שאלון ואן־הילה</h3>
+    <p>כלי הערכה מקוון המבוסס על מודל ואן־הילה לחשיבה גיאומטרית. השאלון ממפה את רמת ההבנה הגיאומטרית של
+      הלומד, ומספק לצוות ההוראה תמונה ברורה שמסייעת להתאים את דרך ההוראה לכל תלמיד.</p>
   </div>
   <div class="home-card home-card--green">
-    <h3>כותרת 2</h3>
-    <p>Proident est excepteur esse non voluptate do anim est. Velit do amet laborum ea consequat nulla. Proident quis aliqua
-      laborum laboris elit enim consectetur nisi ad. Reprehenderit in proident eiusmod consequat et labore.</p>
+    <h3>כלים פדגוגיים אינטראקטיביים</h3>
+    <p>יישומונים חזותיים להוכחת משפט פיתגורס באמצעות גרירה, חיתוך והרכבה מחדש של צורות. הכלים מאפשרים
+      ללומדים לחקור רעיונות גיאומטריים בעצמם, עוד לפני שהם פוגשים את הנוסחה.</p>
   </div>
   <div class="home-card home-card--orange">
-    <h3>כותרת 3</h3>
-    <p>Proident est excepteur esse non voluptate do anim est. Velit do amet laborum ea consequat nulla. Proident quis aliqua
-      laborum laboris elit enim consectetur nisi ad. Reprehenderit in proident eiusmod consequat et labore.</p>
+    <h3>ספרייה מחקרית ולימודית</h3>
+    <p>אוסף מאמרים, מקורות ולומדות שנאספו במיוחד עבור מורים וסטודנטים להוראת המתמטיקה, לצד קישורי ענן
+      שימושיים לכיתה. כל החומרים מאורגנים ונגישים במקום אחד.</p>
   </div>
 </div>

--- a/angular-src/src/app/home/home.component.html
+++ b/angular-src/src/app/home/home.component.html
@@ -1,24 +1,22 @@
-<div class="jumbotron text-center margin">
+<div class="home-hero" dir="rtl">
   <h1>מתמטיקה - למידה ומחקר</h1>
-  <p>
-    ברוכים הבאים לאתר מתמטיקה - למידה ומחקר 
-  </p>
-  <p>לימינכם אופציות הקיימות</p>
+  <p class="hero-subtitle">ברוכים הבאים לאתר מתמטיקה - למידה ומחקר</p>
+  <p class="hero-sub">לימינכם האופציות הקיימות</p>
 </div>
 
-<div class="row" style="margin-right: 50px ; color:white">
-  <div class="col-md-4">
+<div class="home-cards" dir="rtl">
+  <div class="home-card home-card--blue">
     <h3>כותרת 1</h3>
     <p>Proident est excepteur esse non voluptate do anim est. Velit do amet laborum ea consequat nulla. Proident quis aliqua
       laborum laboris elit enim consectetur nisi ad. Reprehenderit in proident eiusmod consequat et labore.</p>
   </div>
-  <div class="col-md-4">
-      <h3>כותרת 2</h3>
+  <div class="home-card home-card--green">
+    <h3>כותרת 2</h3>
     <p>Proident est excepteur esse non voluptate do anim est. Velit do amet laborum ea consequat nulla. Proident quis aliqua
       laborum laboris elit enim consectetur nisi ad. Reprehenderit in proident eiusmod consequat et labore.</p>
   </div>
-  <div class="col-md-2">
-      <h3>כותרת 3</h3>
+  <div class="home-card home-card--orange">
+    <h3>כותרת 3</h3>
     <p>Proident est excepteur esse non voluptate do anim est. Velit do amet laborum ea consequat nulla. Proident quis aliqua
       laborum laboris elit enim consectetur nisi ad. Reprehenderit in proident eiusmod consequat et labore.</p>
   </div>

--- a/angular-src/src/app/login/login.component.css
+++ b/angular-src/src/app/login/login.component.css
@@ -1,0 +1,40 @@
+.auth-page {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 16px;
+  min-height: calc(100vh - 60px);
+}
+
+.auth-card {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  padding: 48px 40px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.auth-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1F2937;
+  margin-bottom: 32px;
+  margin-top: 0;
+  text-align: center;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.auth-submit {
+  margin-top: 8px;
+}
+
+.auth-btn {
+  height: 46px;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}

--- a/angular-src/src/app/login/login.component.css
+++ b/angular-src/src/app/login/login.component.css
@@ -38,3 +38,8 @@
   font-weight: 600;
   letter-spacing: 0.3px;
 }
+
+@media (max-width: 767px) {
+  .auth-page { padding: 24px 12px; }
+  .auth-card { padding: 32px 20px; }
+}

--- a/angular-src/src/app/login/login.component.css
+++ b/angular-src/src/app/login/login.component.css
@@ -4,23 +4,33 @@
   align-items: flex-start;
   padding: 48px 16px;
   min-height: calc(100vh - 60px);
+  background: linear-gradient(160deg, #EEF2FF 0%, #F7F8FD 45%, #ECFDF5 100%);
 }
 
 .auth-card {
   background-color: #FFFFFF;
   border-radius: 20px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
-  padding: 48px 40px;
   width: 100%;
   max-width: 420px;
+  overflow: hidden;
+}
+
+.auth-card-header {
+  background: linear-gradient(135deg, #5B7FFF 0%, #38C172 100%);
+  padding: 32px 40px 28px;
+  text-align: center;
+}
+
+.auth-card-body {
+  padding: 32px 40px 40px;
 }
 
 .auth-title {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #1F2937;
-  margin-bottom: 32px;
-  margin-top: 0;
+  color: #FFFFFF;
+  margin: 0;
   text-align: center;
 }
 
@@ -33,13 +43,14 @@
 }
 
 .auth-btn {
-  height: 46px;
-  font-size: 1rem;
+  height: 48px;
+  font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: 0.3px;
 }
 
 @media (max-width: 767px) {
   .auth-page { padding: 24px 12px; }
-  .auth-card { padding: 32px 20px; }
+  .auth-card-header { padding: 24px 20px 20px; }
+  .auth-card-body { padding: 24px 20px 28px; }
 }

--- a/angular-src/src/app/login/login.component.html
+++ b/angular-src/src/app/login/login.component.html
@@ -1,20 +1,20 @@
-<div class="col-md-10" style="text-align: center;color: white">
-    <h2 class="page-header">טופס כניסה</h2>
+<div class="auth-page">
+  <div class="auth-card" dir="rtl">
+    <h2 class="auth-title">כניסה למערכת</h2>
+    <form (submit)="login()">
+      <div class="form-group">
+        <label for="username">שם משתמש</label>
+        <input type="text" id="username" name="username" [(ngModel)]="username"
+               class="form-control" placeholder="הכנס שם משתמש">
+      </div>
+      <div class="form-group">
+        <label for="password">סיסמא</label>
+        <input type="password" id="password" name="password" [(ngModel)]="password"
+               class="form-control" placeholder="הכנס סיסמא">
+      </div>
+      <div class="form-group auth-submit">
+        <button type="submit" class="btn btn-primary btn-block auth-btn">התחבר</button>
+      </div>
+    </form>
   </div>
-  <form (submit)="login()" style="color:white">
-    <!-- <div class="form-group col-md-10 col-md-pull-0" dir="rtl">
-      <label for="">אימייל</label>
-      <input type="email" name="email" [(ngModel)]="email" class="form-control" placeholder="הכנס אימייל">
-    </div> -->
-    <div class="form-group col-md-10 col-md-pull-0" dir="rtl">
-      <label for="">שם משתמש</label>
-      <input type="text" name="username" [(ngModel)]="username" class="form-control" placeholder="הכנס שם משתמש">
-    </div>
-    <div class="form-group col-md-10 col-md-pull-0" dir="rtl">
-      <label for="">סיסמא</label>
-      <input type="password" name="password" [(ngModel)]="password" class="form-control" placeholder="הכנס סיסמא">
-    </div>
-    <div class="form-group col-md-10 col-md-pull-0">
-      <button type="submit" class="btn btn-primary btn-lg">התחבר</button>
-    </div>
-  </form>
+</div>

--- a/angular-src/src/app/login/login.component.html
+++ b/angular-src/src/app/login/login.component.html
@@ -1,20 +1,24 @@
 <div class="auth-page">
   <div class="auth-card" dir="rtl">
-    <h2 class="auth-title">כניסה למערכת</h2>
-    <form (submit)="login()">
-      <div class="form-group">
-        <label for="username">שם משתמש</label>
-        <input type="text" id="username" name="username" [(ngModel)]="username"
-               class="form-control" placeholder="הכנס שם משתמש">
-      </div>
-      <div class="form-group">
-        <label for="password">סיסמא</label>
-        <input type="password" id="password" name="password" [(ngModel)]="password"
-               class="form-control" placeholder="הכנס סיסמא">
-      </div>
-      <div class="form-group auth-submit">
-        <button type="submit" class="btn btn-primary btn-block auth-btn">התחבר</button>
-      </div>
-    </form>
+    <div class="auth-card-header">
+      <h2 class="auth-title">כניסה למערכת</h2>
+    </div>
+    <div class="auth-card-body">
+      <form (submit)="login()">
+        <div class="form-group">
+          <label for="username">שם משתמש</label>
+          <input type="text" id="username" name="username" [(ngModel)]="username"
+                 class="form-control" placeholder="הכנס שם משתמש">
+        </div>
+        <div class="form-group">
+          <label for="password">סיסמא</label>
+          <input type="password" id="password" name="password" [(ngModel)]="password"
+                 class="form-control" placeholder="הכנס סיסמא">
+        </div>
+        <div class="form-group auth-submit">
+          <button type="submit" class="btn btn-primary btn-block auth-btn">התחבר</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/angular-src/src/app/login/login.component.ts
+++ b/angular-src/src/app/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import {AuthService  } from "../services/auth.service";
 import { Router } from "@angular/router";
-import { FlashMessagesService } from "angular2-flash-messages";
+import { ToastrService } from "ngx-toastr";
 
 @Component({
   selector: 'app-login',
@@ -13,7 +13,7 @@ export class LoginComponent implements OnInit {
   password:String;
   constructor(private auth:AuthService,
     private router:Router,
-    private flashMSG:FlashMessagesService) { }
+    private toastr:ToastrService) { }
 
   ngOnInit() {
   }
@@ -27,11 +27,11 @@ export class LoginComponent implements OnInit {
       if(data.success){
         //console.log(data.siteUser)
         this.auth.storeUserData(data.token,data.siteUser.username);
-        this.flashMSG.show('התחברת בהצלחה',{cssClass:'alert-success',timeout:3000});
+        this.toastr.success('התחברת בהצלחה');
         this.router.navigate(['/profile']);
 
       }else{
-        this.flashMSG.show(data.msg,{cssClass:'alert-danger',timeout:3000});
+        this.toastr.error(data.msg);
         this.router.navigate(['/login']);
       }
     })

--- a/angular-src/src/app/navbar/navbar.component.css
+++ b/angular-src/src/app/navbar/navbar.component.css
@@ -88,7 +88,7 @@ body {
 }
 
 /* =====================================================
-   Mobile: full-width dropdown (< 768px)
+   Mobile: full-screen overlay (< 768px)
    ===================================================== */
 @media (max-width: 767px) {
   .side-nav {
@@ -98,16 +98,25 @@ body {
     box-shadow: none;
   }
 
-  /* When open, show below navbar */
-  .navbar-ex1-collapse.in {
-    display: block !important;
-    overflow-y: auto;
-    max-height: calc(100vh - 60px);
+  /* Overlay covers full screen below the navbar bar */
+  .navbar-ex1-collapse {
+    background-color: #1F2937;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0;
   }
 
-  .navbar-collapse {
-    padding: 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  .navbar-ex1-collapse.in,
+  .navbar-ex1-collapse.collapsing {
+    position: fixed;
+    top: 60px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow-y: auto;
+    z-index: 1030;
+    background-color: #1F2937;
+    /* Reset Bootstrap's max-height so it fills the screen */
+    max-height: none !important;
   }
 }
 

--- a/angular-src/src/app/navbar/navbar.component.css
+++ b/angular-src/src/app/navbar/navbar.component.css
@@ -21,9 +21,24 @@ body {
   color: #FFFFFF !important;
   padding: 18px 20px;
   letter-spacing: 0.5px;
+  float: right;
 }
 
-/* Top nav links (login / logout / profile) */
+/* Hamburger toggle button */
+.navbar-inverse .navbar-toggle {
+  border-color: rgba(255, 255, 255, 0.2) !important;
+  margin: 13px 15px;
+  float: left;
+}
+.navbar-inverse .navbar-toggle .icon-bar {
+  background-color: #D1D5DB !important;
+}
+.navbar-inverse .navbar-toggle:hover,
+.navbar-inverse .navbar-toggle:focus {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+/* Top nav links */
 .top-nav > li > a {
   font-family: 'Rubik', Arial, sans-serif;
   font-weight: 500;
@@ -33,26 +48,21 @@ body {
   transition: color 0.15s ease, background-color 0.15s ease;
   border-bottom: 3px solid transparent;
 }
-
 .top-nav > li > a:hover,
 .top-nav > li > a:focus {
   color: #FFFFFF !important;
   background-color: rgba(255, 255, 255, 0.06) !important;
   border-bottom-color: #5B7FFF;
 }
-
 .top-nav > li.active > a {
   color: #FFFFFF !important;
   border-bottom-color: #5B7FFF;
 }
 
-/* Sidebar (side-nav) */
+/* =====================================================
+   Desktop: fixed sidebar (>= 768px)
+   ===================================================== */
 @media (min-width: 768px) {
-  #wrapper {
-    padding-right: 220px;
-    padding-left: 0;
-  }
-
   .side-nav {
     position: fixed;
     top: 60px;
@@ -68,9 +78,43 @@ body {
     border-radius: 0;
     box-shadow: -2px 0 8px rgba(0, 0, 0, 0.12);
   }
+
+  /* Hide the collapse wrapper on desktop — always show */
+  .navbar-ex1-collapse {
+    display: block !important;
+    height: auto !important;
+    overflow: visible !important;
+  }
 }
 
-/* Side-nav top-level links */
+/* =====================================================
+   Mobile: full-width dropdown (< 768px)
+   ===================================================== */
+@media (max-width: 767px) {
+  .side-nav {
+    position: static;
+    width: 100%;
+    background-color: #1F2937;
+    box-shadow: none;
+  }
+
+  /* When open, show below navbar */
+  .navbar-ex1-collapse.in {
+    display: block !important;
+    overflow-y: auto;
+    max-height: calc(100vh - 60px);
+  }
+
+  .navbar-collapse {
+    padding: 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  }
+}
+
+/* =====================================================
+   Side-nav link styles (shared)
+   ===================================================== */
+
 .side-nav > li > a {
   font-family: 'Rubik', Arial, sans-serif;
   font-weight: 500;
@@ -81,11 +125,7 @@ body {
   text-decoration: none;
   transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
   border-right: 3px solid transparent;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
-
 .side-nav > li > a:hover,
 .side-nav > li > a:focus {
   color: #FFFFFF !important;
@@ -93,20 +133,18 @@ body {
   border-right-color: #5B7FFF;
   outline: none;
 }
-
 .side-nav > li.active > a {
   color: #FFFFFF !important;
   background-color: rgba(91, 127, 255, 0.18) !important;
   border-right-color: #5B7FFF;
 }
 
-/* Side-nav sub-menu links */
+/* Sub-menus */
 .side-nav > li > ul {
   padding: 0;
   background-color: rgba(0, 0, 0, 0.15);
   list-style: none;
 }
-
 .side-nav > li > ul > li > a {
   font-family: 'Rubik', Arial, sans-serif;
   font-weight: 400;
@@ -118,7 +156,6 @@ body {
   transition: color 0.15s ease, background-color 0.15s ease;
   border-right: 3px solid transparent;
 }
-
 .side-nav > li > ul > li > a:hover {
   color: #FFFFFF !important;
   background-color: rgba(91, 127, 255, 0.10) !important;
@@ -131,7 +168,6 @@ body {
   background-color: rgba(0, 0, 0, 0.1);
   list-style: none;
 }
-
 .side-nav > li > ul > li > ul > li > a {
   font-family: 'Rubik', Arial, sans-serif;
   font-weight: 400;
@@ -142,25 +178,21 @@ body {
   text-decoration: none;
   transition: color 0.15s ease, background-color 0.15s ease;
 }
-
 .side-nav > li > ul > li > ul > li > a:hover {
   color: #FFFFFF !important;
   background-color: rgba(91, 127, 255, 0.10) !important;
 }
 
-/* Divider between nav sections */
 .side-nav > li:not(:last-child) {
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-/* Caret icons */
 .fa-caret-down {
   float: left;
   margin-top: 3px;
   color: #6B7280;
 }
 
-/* Page wrapper */
 #page-wrapper {
   width: 100%;
   padding: 24px;

--- a/angular-src/src/app/navbar/navbar.component.css
+++ b/angular-src/src/app/navbar/navbar.component.css
@@ -1,244 +1,168 @@
-/*!
- * Start Bootstrap - SB Admin (http://startbootstrap.com/)
- * Copyright 2013-2016 Start Bootstrap
- * Licensed under MIT (https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE)
- */
-
-/* Global Styles */
+/* =====================================================
+   Navbar
+   ===================================================== */
 
 body {
-    margin-top: 100px;
-    background-color: #222;
+  margin-top: 60px;
 }
 
-/* @media(min-width:768px) {
-    body {
-        margin-top: 50px;
-    }
-} */
+/* Top navbar bar */
+.navbar-inverse {
+  background-color: #1F2937 !important;
+  border: none !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  min-height: 60px;
+}
 
+.navbar-inverse .navbar-brand {
+  font-family: 'Rubik', Arial, sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #FFFFFF !important;
+  padding: 18px 20px;
+  letter-spacing: 0.5px;
+}
 
-#wrapper {
+/* Top nav links (login / logout / profile) */
+.top-nav > li > a {
+  font-family: 'Rubik', Arial, sans-serif;
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: #D1D5DB !important;
+  padding: 20px 16px;
+  transition: color 0.15s ease, background-color 0.15s ease;
+  border-bottom: 3px solid transparent;
+}
+
+.top-nav > li > a:hover,
+.top-nav > li > a:focus {
+  color: #FFFFFF !important;
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  border-bottom-color: #5B7FFF;
+}
+
+.top-nav > li.active > a {
+  color: #FFFFFF !important;
+  border-bottom-color: #5B7FFF;
+}
+
+/* Sidebar (side-nav) */
+@media (min-width: 768px) {
+  #wrapper {
+    padding-right: 220px;
     padding-left: 0;
-}
+  }
 
-#page-wrapper {
-    width: 100%;
-    padding: 0;
-    background-color: #fff;
-}
-
-.huge {
-    font-size: 50px;
-    line-height: normal;
-}
-
-@media(min-width:768px) {
-    #wrapper {
-        padding-left: 225px;
-    }
-
-    #page-wrapper {
-        padding: 10px;
-    }
-}
-
-/* Top Navigation */
-
-.top-nav {
-    padding: 0 15px;
-}
-
-.top-nav>li {
-    display: inline-block;
-    float: left;
-}
-
-.top-nav>li>a {
-    padding-top: 15px;
-    padding-bottom: 15px;
-    line-height: 20px;
-    color: #999;
-}
-
-.top-nav>li>a:hover,
-.top-nav>li>a:focus,
-.top-nav>.open>a,
-.top-nav>.open>a:hover,
-.top-nav>.open>a:focus {
-    color: #fff;
-    background-color: #000;
-}
-
-.top-nav>.open>.dropdown-menu {
-    float: left;
-    position: absolute;
-    margin-top: 0;
-    border: 1px solid rgba(0,0,0,.15);
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    background-color: #fff;
-    -webkit-box-shadow: 0 6px 12px rgba(0,0,0,.175);
-    box-shadow: 0 6px 12px rgba(0,0,0,.175);
-}
-
-.top-nav>.open>.dropdown-menu>li>a {
-    white-space: normal;
-}
-
-ul.message-dropdown {
-    padding: 0;
-    max-height: 250px;
-    overflow-x: hidden;
+  .side-nav {
+    position: fixed;
+    top: 60px;
+    right: 0;
+    left: auto;
+    width: 220px;
+    bottom: 0;
+    background-color: #1F2937;
     overflow-y: auto;
+    overflow-x: hidden;
+    padding-bottom: 40px;
+    border: none;
+    border-radius: 0;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.12);
+  }
 }
 
-li.message-preview {
-    width: 275px;
-    border-bottom: 1px solid rgba(0,0,0,.15);
+/* Side-nav top-level links */
+.side-nav > li > a {
+  font-family: 'Rubik', Arial, sans-serif;
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: #D1D5DB !important;
+  padding: 12px 20px;
+  display: block;
+  text-decoration: none;
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+  border-right: 3px solid transparent;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-li.message-preview>a {
-    padding-top: 15px;
-    padding-bottom: 15px;
+.side-nav > li > a:hover,
+.side-nav > li > a:focus {
+  color: #FFFFFF !important;
+  background-color: rgba(91, 127, 255, 0.12) !important;
+  border-right-color: #5B7FFF;
+  outline: none;
 }
 
-li.message-footer {
-    margin: 5px 0;
+.side-nav > li.active > a {
+  color: #FFFFFF !important;
+  background-color: rgba(91, 127, 255, 0.18) !important;
+  border-right-color: #5B7FFF;
 }
 
-ul.alert-dropdown {
-    width: 200px;
+/* Side-nav sub-menu links */
+.side-nav > li > ul {
+  padding: 0;
+  background-color: rgba(0, 0, 0, 0.15);
+  list-style: none;
 }
 
-/* Side Navigation */
-
-@media(min-width:768px) {
-    .side-nav {
-        position: fixed;
-        top: 51px;
-        left: 225px;
-        width: 215px;
-        margin-left: -225px;
-        border: none;
-        border-radius: 0;
-        overflow-y: auto;
-        background-color: #222222;
-        bottom: 0;
-        overflow-x: hidden;
-        padding-bottom: 40px;
-    }
-@media (min-width: 768px){
-  #wrapper {padding-right: 200px; padding-left: 0;}
-  .side-nav{right: 0;left: auto;}
-}
-    .side-nav>li>a {
-        width: 225px;
-    }
-    
-
-    .side-nav li a:hover,
-    .side-nav li a:focus {
-        outline: none;
-        background-color: #000 !important;
-    }
+.side-nav > li > ul > li > a {
+  font-family: 'Rubik', Arial, sans-serif;
+  font-weight: 400;
+  font-size: 0.875rem;
+  color: #9CA3AF !important;
+  display: block;
+  padding: 9px 20px 9px 36px;
+  text-decoration: none;
+  transition: color 0.15s ease, background-color 0.15s ease;
+  border-right: 3px solid transparent;
 }
 
-.side-nav>li>ul {
-    padding: 0;
+.side-nav > li > ul > li > a:hover {
+  color: #FFFFFF !important;
+  background-color: rgba(91, 127, 255, 0.10) !important;
+  border-right-color: #5B7FFF;
 }
 
-.side-nav>li>ul>li>a {
-    display: block;
-    padding: 10px 15px 10px 38px;
-    text-decoration: none;
-    color: #999;
-}
-.side-nav>li>ul>li>a>li>a {
-    display: block;
-    padding: 10px 15px 10px 38px;
-    text-decoration: none;
-    color: #999;
+/* Third-level sub-menu */
+.side-nav > li > ul > li > ul {
+  padding: 0;
+  background-color: rgba(0, 0, 0, 0.1);
+  list-style: none;
 }
 
-.side-nav>li>ul>li>a>li>a:hover {
-    color: #fff;
+.side-nav > li > ul > li > ul > li > a {
+  font-family: 'Rubik', Arial, sans-serif;
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: #9CA3AF !important;
+  display: block;
+  padding: 8px 20px 8px 50px;
+  text-decoration: none;
+  transition: color 0.15s ease, background-color 0.15s ease;
 }
 
-.side-nav>li>ul>li>a:hover {
-    color: #fff;
+.side-nav > li > ul > li > ul > li > a:hover {
+  color: #FFFFFF !important;
+  background-color: rgba(91, 127, 255, 0.10) !important;
 }
 
-
-
-/* Flot Chart Containers */
-
-.flot-chart {
-    display: block;
-    height: 400px;
+/* Divider between nav sections */
+.side-nav > li:not(:last-child) {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-.flot-chart-content {
-    width: 100%;
-    height: 100%;
+/* Caret icons */
+.fa-caret-down {
+  float: left;
+  margin-top: 3px;
+  color: #6B7280;
 }
 
-/* Custom Colored Panels */
-
-.huge {
-    font-size: 40px;
-}
-
-.panel-green {
-    border-color: #5cb85c;
-}
-
-.panel-green > .panel-heading {
-    border-color: #5cb85c;
-    color: #fff;
-    background-color: #5cb85c;
-}
-
-.panel-green > a {
-    color: #5cb85c;
-}
-
-.panel-green > a:hover {
-    color: #3d8b3d;
-}
-
-.panel-red {
-    border-color: #d9534f;
-}
-
-.panel-red > .panel-heading {
-    border-color: #d9534f;
-    color: #fff;
-    background-color: #d9534f;
-}
-
-.panel-red > a {
-    color: #d9534f;
-}
-
-.panel-red > a:hover {
-    color: #b52b27;
-}
-
-.panel-yellow {
-    border-color: #f0ad4e;
-}
-
-.panel-yellow > .panel-heading {
-    border-color: #f0ad4e;
-    color: #fff;
-    background-color: #f0ad4e;
-}
-
-.panel-yellow > a {
-    color: #f0ad4e;
-}
-
-.panel-yellow > a:hover {
-    color: #df8a13;
+/* Page wrapper */
+#page-wrapper {
+  width: 100%;
+  padding: 24px;
+  background-color: transparent;
 }

--- a/angular-src/src/app/navbar/navbar.component.css
+++ b/angular-src/src/app/navbar/navbar.component.css
@@ -24,6 +24,16 @@ body {
   float: right;
 }
 
+/* Keep the brand and the login/profile links on the same row at every width
+   instead of letting the unfloated .navbar-header block push top-nav to a
+   second row (which made the bar taller than the 60px offset content expects) */
+.navbar-inverse .navbar-header {
+  float: right;
+}
+.navbar-inverse .top-nav-wrap {
+  float: left;
+}
+
 /* Hamburger toggle button */
 .navbar-inverse .navbar-toggle {
   border-color: rgba(255, 255, 255, 0.2) !important;
@@ -111,18 +121,36 @@ body {
     top: 60px;
     left: 0;
     right: 0;
-    bottom: 0;
     overflow-y: auto;
     z-index: 1030;
     background-color: #1F2937;
-    /* Reset Bootstrap's max-height so it fills the screen */
-    max-height: none !important;
+    /* Size to content instead of Bootstrap's small default cap, but never exceed the viewport */
+    max-height: calc(100vh - 60px) !important;
   }
 }
 
 /* =====================================================
    Side-nav link styles (shared)
    ===================================================== */
+
+/* Bootstrap's .nav class only zeroes padding-left (a physical property). Under
+   dir="rtl" the browser's default UA list padding is a logical padding-inline-start,
+   which resolves to padding-right — left un-reset, it eats into the right side of
+   the sidebar and squeezes every row, separator and active state to the left. */
+.side-nav {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Bootstrap's default .navbar-nav responsive CSS floats each <li> at desktop
+   widths (built for a horizontal top-nav) and shrinks every row to its text
+   width instead of the full sidebar width. This is a vertical sidebar, not a
+   horizontal nav, so every row must stay a full-width block regardless of viewport. */
+.side-nav > li {
+  float: none;
+  width: 100%;
+}
 
 .side-nav > li > a {
   font-family: 'Rubik', Arial, sans-serif;

--- a/angular-src/src/app/navbar/navbar.component.html
+++ b/angular-src/src/app/navbar/navbar.component.html
@@ -1,74 +1,73 @@
 <div id="wrapper">
-  <!-- Navigation -->
   <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header pull-right">
+    <div class="navbar-header">
+      <!-- Hamburger toggle (mobile) -->
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
       <a class="navbar-brand" [routerLink]="['/']">Math</a>
     </div>
+
+    <!-- Top nav links -->
     <div>
       <ul class="nav navbar-nav navbar-left top-nav">
-        <!-- <li *ngIf="!auth.loggedIn()">
-          <a [routerLink]="['register']"><i class="fa fa-fw fa-dashboard"></i>רישום</a>
-        </li> -->
         <li *ngIf="!auth.loggedIn()">
-          <a [routerLink]="['login']"><i class="fa fa-fw fa-dashboard"></i>כניסה</a>
+          <a [routerLink]="['login']">כניסה</a>
         </li>
         <li *ngIf="auth.loggedIn()">
-          <a (click)="onLogout()" href="#"><i class="fa fa-fw fa-dashboard"></i>התנתק</a>
+          <a (click)="onLogout()" href="#">התנתק</a>
         </li>
         <li *ngIf="auth.loggedIn()">
-          <a [routerLink]="['profile']"><i class="fa fa-fw fa-dashboard"></i>פרופיל</a>
+          <a [routerLink]="['profile']">פרופיל</a>
         </li>
         <li *ngIf="auth.loggedIn()">
-          <a [routerLink]="['dashboard']"><i class="fa fa-fw fa-dashboard"></i>לוח עבודה</a>
+          <a [routerLink]="['dashboard']">לוח עבודה</a>
         </li>
       </ul>
     </div>
-    <!-- Sidebar Menu Items - These collapse to the responsive navigation menu on small screens -->
+
+    <!-- Sidebar / collapsible menu -->
     <div class="collapse navbar-collapse navbar-ex1-collapse" dir="rtl">
       <ul class="nav navbar-nav side-nav pull-right">
         <li>
-          <a [routerLink]="['cloudlinks']"><i class="fa fa-fw fa-dashboard"></i>קישורים לענן</a>
+          <a [routerLink]="['cloudlinks']">קישורים לענן</a>
         </li>
         <li>
-          <a [routerLink]="['reslit']"><i class="fa fa-fw fa-bar-chart-o"></i>ספרות מחקרית</a>
+          <a [routerLink]="['reslit']">ספרות מחקרית</a>
         </li>
         <li>
-          <a [routerLink]="['edulit']"><i class="fa fa-fw fa-table"></i>ספרות לימודית</a>
+          <a [routerLink]="['edulit']">ספרות לימודית</a>
         </li>
         <li>
-          <a href="javascript:;" data-toggle="collapse" data-target="#demo"><i class="fa fa-fw fa-arrows-v"></i>כלים פדגוגיים<i class="fa fa-fw fa-caret-down"></i></a>
+          <a href="javascript:;" data-toggle="collapse" data-target="#demo">
+            כלים פדגוגיים <i class="fa fa-fw fa-caret-down"></i>
+          </a>
           <ul id="demo" class="collapse">
-            <li>
-              <a [routerLink]="['vanhilequiz']">שאלון ואן הילה</a>
-            </li>
-            <li>
-              <a [routerLink]="['pythagorean']">משפט פיתגורס</a>
-            </li>
-            <li>
-              <a [routerLink]="['pythagorean-cutting']">משפט פיתגורס – כלי חיתוך</a>
-            </li>
+            <li><a [routerLink]="['vanhilequiz']">שאלון ואן הילה</a></li>
+            <li><a [routerLink]="['pythagorean']">משפט פיתגורס</a></li>
+            <li><a [routerLink]="['pythagorean-cutting']">משפט פיתגורס – כלי חיתוך</a></li>
           </ul>
         </li>
         <li *ngIf="auth.loggedIn()">
-          <a href="javascript:;" data-toggle="collapse" data-target="#repo"><i class="fa fa-fw fa-arrows-v"></i>דו"חות<i class="fa fa-fw fa-caret-down"></i></a>
+          <a href="javascript:;" data-toggle="collapse" data-target="#repo">
+            דו"חות <i class="fa fa-fw fa-caret-down"></i>
+          </a>
           <ul id="repo" class="collapse">
             <li>
-              <a href="javascript:;" data-toggle="collapse" data-target="#VanHilleRepo"><i class="fa fa-fw fa-arrows-v"></i>דו"חות ואן הילה<i class="fa fa-fw fa-caret-down"></i></a>
+              <a href="javascript:;" data-toggle="collapse" data-target="#VanHilleRepo">
+                דו"חות ואן הילה <i class="fa fa-fw fa-caret-down"></i>
+              </a>
               <ul id="VanHilleRepo" class="collapse">
-                <li>
-                  <a [routerLink]="['vanhille/studentreport']">דו"ח לסטודנט</a>
-                </li>
-                <li>
-                  <a [routerLink]="['vanhille/classreport']">דו"ח כללי</a>
-                </li>
+                <li><a [routerLink]="['vanhille/studentreport']">דו"ח לסטודנט</a></li>
+                <li><a [routerLink]="['vanhille/classreport']">דו"ח כללי</a></li>
               </ul>
             </li>
           </ul>
         </li>
-
       </ul>
     </div>
-    <!-- /.navbar-collapse -->
   </nav>
 </div>

--- a/angular-src/src/app/navbar/navbar.component.html
+++ b/angular-src/src/app/navbar/navbar.component.html
@@ -12,7 +12,7 @@
     </div>
 
     <!-- Top nav links -->
-    <div>
+    <div class="top-nav-wrap">
       <ul class="nav navbar-nav navbar-left top-nav">
         <li *ngIf="!auth.loggedIn()">
           <a [routerLink]="['login']">כניסה</a>

--- a/angular-src/src/app/navbar/navbar.component.html
+++ b/angular-src/src/app/navbar/navbar.component.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" [routerLink]="['/']">Math</a>
+      <a class="navbar-brand" [routerLink]="['/']">זווית</a>
     </div>
 
     <!-- Top nav links -->

--- a/angular-src/src/app/navbar/navbar.component.ts
+++ b/angular-src/src/app/navbar/navbar.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import {AuthService  } from "../services/auth.service";
 import { Router } from "@angular/router";
-import { FlashMessagesService } from "angular2-flash-messages";
+import { ToastrService } from "ngx-toastr";
 
 @Component({
   selector: 'app-navbar',
@@ -12,7 +12,7 @@ export class NavbarComponent implements OnInit {
   SiteUser:any = localStorage.getItem('admin');
   constructor(
     private auth:AuthService,
-    private flashMSG:FlashMessagesService,
+    private toastr:ToastrService,
     private router: Router
   ) { }
 
@@ -20,7 +20,7 @@ export class NavbarComponent implements OnInit {
   }
   onLogout(){
     this.auth.logout();
-    this.flashMSG.show('התנתקת',{cssClass:'alert-danger',timeout:3000});
+    this.toastr.info('התנתקת');
     this.router.navigate(['/login']);
     return false;
   }

--- a/angular-src/src/app/profile/profile.component.css
+++ b/angular-src/src/app/profile/profile.component.css
@@ -1,0 +1,106 @@
+.profile-page {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 16px;
+  min-height: calc(100vh - 60px);
+  background: linear-gradient(160deg, #EEF2FF 0%, #F7F8FD 45%, #ECFDF5 100%);
+}
+
+.profile-card {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  width: 100%;
+  max-width: 420px;
+  overflow: hidden;
+}
+
+.profile-card-header {
+  background: linear-gradient(135deg, #5B7FFF 0%, #38C172 100%);
+  padding: 32px 40px 28px;
+  text-align: center;
+}
+
+.profile-avatar {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  color: #FFFFFF;
+  font-size: 1.8rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-name {
+  color: #FFFFFF;
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.profile-card-body {
+  padding: 32px 40px 40px;
+}
+
+.profile-info-list {
+  list-style: none;
+  margin: 0 0 24px;
+  padding: 0;
+}
+
+.profile-info-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px solid #E5E7EB;
+}
+
+.profile-info-item:last-child {
+  border-bottom: none;
+}
+
+.profile-info-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #6B7280;
+}
+
+.profile-info-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1F2937;
+}
+
+.profile-cta {
+  height: 48px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-card--loading .profile-card-body {
+  padding: 40px;
+  text-align: center;
+}
+
+.profile-loading-text {
+  color: #6B7280;
+  font-size: 1rem;
+  margin: 0;
+}
+
+@media (max-width: 767px) {
+  .profile-page { padding: 24px 12px; }
+  .profile-card-header { padding: 24px 20px 20px; }
+  .profile-card-body { padding: 24px 20px 28px; }
+}

--- a/angular-src/src/app/profile/profile.component.html
+++ b/angular-src/src/app/profile/profile.component.html
@@ -1,13 +1,33 @@
-<div *ngIf="user" class="col-md-10">
-  <h2 class="page-header" style="text-align: center;color: white">
-    {{user.username}}
-  </h2>
-  <ul class="list-group">
-    <li class="list-group-item">
-       UserName: {{user.username}}
-    </li>
-    <li class="list-group-item">
-        Email: {{user.email}} 
-    </li>
-  </ul>
+<div class="profile-page">
+  <div *ngIf="user" class="profile-card" dir="rtl">
+    <div class="profile-card-header">
+      <div class="profile-avatar">{{user.username.charAt(0)}}</div>
+      <h2 class="profile-name">{{user.username}}</h2>
+    </div>
+    <div class="profile-card-body">
+      <ul class="profile-info-list">
+        <li class="profile-info-item">
+          <span class="profile-info-label">שם משתמש</span>
+          <span class="profile-info-value">{{user.username}}</span>
+        </li>
+        <li class="profile-info-item">
+          <span class="profile-info-label">אימייל</span>
+          <span class="profile-info-value">{{user.email}}</span>
+        </li>
+      </ul>
+      <a [routerLink]="['/dashboard']" class="btn btn-primary btn-block profile-cta">לוח עבודה</a>
+    </div>
+  </div>
+
+  <div *ngIf="!user && !loadError" class="profile-card profile-card--loading" dir="rtl">
+    <div class="profile-card-body">
+      <p class="profile-loading-text">טוען פרופיל...</p>
+    </div>
+  </div>
+
+  <div *ngIf="!user && loadError" class="profile-card profile-card--loading" dir="rtl">
+    <div class="profile-card-body">
+      <p class="profile-loading-text">לא ניתן לטעון את הפרופיל כרגע. נסו לרענן את הדף.</p>
+    </div>
+  </div>
 </div>

--- a/angular-src/src/app/profile/profile.component.ts
+++ b/angular-src/src/app/profile/profile.component.ts
@@ -7,7 +7,8 @@ import { Router } from "@angular/router";
   styleUrls: ['./profile.component.css']
 })
 export class ProfileComponent implements OnInit {
-  user:Object;
+  user:any;
+  loadError:boolean = false;
   constructor(private auth:AuthService,private router:Router) { }
 
   ngOnInit() {
@@ -16,8 +17,7 @@ export class ProfileComponent implements OnInit {
     },
     err=>{
       console.log(err);
-      return false;
-      
+      this.loadError = true;
   })
   }
 

--- a/angular-src/src/app/pythagorean-cutting/pythagorean-cutting.component.css
+++ b/angular-src/src/app/pythagorean-cutting/pythagorean-cutting.component.css
@@ -2,7 +2,7 @@
   max-width: 1180px;
   margin: 22px auto;
   padding: 14px;
-  font-family: Arial, sans-serif;
+  font-family: 'Rubik', Arial, sans-serif;
   background: #f7f8fb;
   color: #111827;
   direction: rtl;
@@ -41,7 +41,7 @@
 }
 
 .pyth-cut-task-section strong {
-  color: #1e40af;
+  color: #3D5FE0;
 }
 
 .pyth-cut-task ul {
@@ -60,7 +60,7 @@
   border: 0;
   border-radius: 12px;
   padding: 10px 13px;
-  background: #2563eb;
+  background: #5B7FFF;
   color: #fff;
   font-size: 15px;
   cursor: pointer;
@@ -72,7 +72,7 @@
 }
 
 .pyth-cut-secondary {
-  background: #64748b;
+  background: #6B7280;
 }
 
 .pyth-cut-stage {

--- a/angular-src/src/app/pythagorean-cutting/pythagorean-cutting.component.css
+++ b/angular-src/src/app/pythagorean-cutting/pythagorean-cutting.component.css
@@ -31,7 +31,7 @@
 
 .pyth-cut-task-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -171,7 +171,7 @@
 
 @media (max-width: 900px) {
   .pyth-cut-task-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .pyth-cut-stage {

--- a/angular-src/src/app/pythagorean/pythagorean.component.css
+++ b/angular-src/src/app/pythagorean/pythagorean.component.css
@@ -24,7 +24,7 @@
 
 .pyth-task-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
 }
 
@@ -115,6 +115,6 @@
 }
 
 @media (max-width: 900px) {
-  .pyth-task-grid { grid-template-columns: 1fr; }
+  .pyth-task-grid { grid-template-columns: minmax(0, 1fr); }
   .pyth-stage     { height: 720px; }
 }

--- a/angular-src/src/app/pythagorean/pythagorean.component.css
+++ b/angular-src/src/app/pythagorean/pythagorean.component.css
@@ -2,7 +2,7 @@
   max-width: 1180px;
   margin: 24px auto;
   padding: 16px;
-  font-family: Arial, sans-serif;
+  font-family: 'Rubik', Arial, sans-serif;
   color: #1f2937;
   direction: rtl;
 }
@@ -33,7 +33,7 @@
   padding-right: 12px;
 }
 
-.pyth-task-section strong { color: #1e40af; }
+.pyth-task-section strong { color: #3D5FE0; }
 
 .pyth-task ul { margin: 6px 0; padding-right: 20px; }
 
@@ -48,15 +48,15 @@
   border: 0;
   border-radius: 12px;
   padding: 10px 14px;
-  background: #2563eb;
+  background: #5B7FFF;
   color: white;
   font-size: 15px;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(0,0,0,.12);
 }
 
-.pyth-btn.pyth-secondary { background: #64748b; }
-.pyth-btn.pyth-success   { background: #059669; }
+.pyth-btn.pyth-secondary { background: #6B7280; }
+.pyth-btn.pyth-success   { background: #38C172; }
 .pyth-btn:hover          { filter: brightness(1.05); }
 
 .pyth-stage {

--- a/angular-src/src/app/register/register.component.css
+++ b/angular-src/src/app/register/register.component.css
@@ -1,0 +1,40 @@
+.auth-page {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 16px;
+  min-height: calc(100vh - 60px);
+}
+
+.auth-card {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  padding: 48px 40px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.auth-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1F2937;
+  margin-bottom: 32px;
+  margin-top: 0;
+  text-align: center;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.auth-submit {
+  margin-top: 8px;
+}
+
+.auth-btn {
+  height: 46px;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}

--- a/angular-src/src/app/register/register.component.css
+++ b/angular-src/src/app/register/register.component.css
@@ -38,3 +38,8 @@
   font-weight: 600;
   letter-spacing: 0.3px;
 }
+
+@media (max-width: 767px) {
+  .auth-page { padding: 24px 12px; }
+  .auth-card { padding: 32px 20px; }
+}

--- a/angular-src/src/app/register/register.component.css
+++ b/angular-src/src/app/register/register.component.css
@@ -4,23 +4,33 @@
   align-items: flex-start;
   padding: 48px 16px;
   min-height: calc(100vh - 60px);
+  background: linear-gradient(160deg, #EEF2FF 0%, #F7F8FD 45%, #ECFDF5 100%);
 }
 
 .auth-card {
   background-color: #FFFFFF;
   border-radius: 20px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
-  padding: 48px 40px;
   width: 100%;
   max-width: 420px;
+  overflow: hidden;
+}
+
+.auth-card-header {
+  background: linear-gradient(135deg, #5B7FFF 0%, #38C172 100%);
+  padding: 32px 40px 28px;
+  text-align: center;
+}
+
+.auth-card-body {
+  padding: 32px 40px 40px;
 }
 
 .auth-title {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #1F2937;
-  margin-bottom: 32px;
-  margin-top: 0;
+  color: #FFFFFF;
+  margin: 0;
   text-align: center;
 }
 
@@ -33,13 +43,14 @@
 }
 
 .auth-btn {
-  height: 46px;
-  font-size: 1rem;
+  height: 48px;
+  font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: 0.3px;
 }
 
 @media (max-width: 767px) {
   .auth-page { padding: 24px 12px; }
-  .auth-card { padding: 32px 20px; }
+  .auth-card-header { padding: 24px 20px 20px; }
+  .auth-card-body { padding: 24px 20px 28px; }
 }

--- a/angular-src/src/app/register/register.component.html
+++ b/angular-src/src/app/register/register.component.html
@@ -1,25 +1,29 @@
 <div class="auth-page">
   <div class="auth-card" dir="rtl">
-    <h2 class="auth-title">הרשמה למערכת</h2>
-    <form (submit)="register()">
-      <div class="form-group">
-        <label for="email">אימייל</label>
-        <input type="email" id="email" name="email" [(ngModel)]="email"
-               class="form-control" placeholder="הכנס אימייל">
-      </div>
-      <div class="form-group">
-        <label for="username">שם משתמש</label>
-        <input type="text" id="username" name="username" [(ngModel)]="username"
-               class="form-control" placeholder="הכנס שם משתמש">
-      </div>
-      <div class="form-group">
-        <label for="password">סיסמא</label>
-        <input type="password" id="password" name="password" [(ngModel)]="password"
-               class="form-control" placeholder="הכנס סיסמא">
-      </div>
-      <div class="form-group auth-submit">
-        <button type="submit" class="btn btn-primary btn-block auth-btn">הרשם</button>
-      </div>
-    </form>
+    <div class="auth-card-header">
+      <h2 class="auth-title">הרשמה למערכת</h2>
+    </div>
+    <div class="auth-card-body">
+      <form (submit)="register()">
+        <div class="form-group">
+          <label for="email">אימייל</label>
+          <input type="email" id="email" name="email" [(ngModel)]="email"
+                 class="form-control" placeholder="הכנס אימייל">
+        </div>
+        <div class="form-group">
+          <label for="username">שם משתמש</label>
+          <input type="text" id="username" name="username" [(ngModel)]="username"
+                 class="form-control" placeholder="הכנס שם משתמש">
+        </div>
+        <div class="form-group">
+          <label for="password">סיסמא</label>
+          <input type="password" id="password" name="password" [(ngModel)]="password"
+                 class="form-control" placeholder="הכנס סיסמא">
+        </div>
+        <div class="form-group auth-submit">
+          <button type="submit" class="btn btn-primary btn-block auth-btn">הרשם</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/angular-src/src/app/register/register.component.html
+++ b/angular-src/src/app/register/register.component.html
@@ -1,21 +1,25 @@
-<div class="col-md-10" style="text-align: center;color: white">
-    <h2 class="page-header">טופס רישום</h2>
+<div class="auth-page">
+  <div class="auth-card" dir="rtl">
+    <h2 class="auth-title">הרשמה למערכת</h2>
+    <form (submit)="register()">
+      <div class="form-group">
+        <label for="email">אימייל</label>
+        <input type="email" id="email" name="email" [(ngModel)]="email"
+               class="form-control" placeholder="הכנס אימייל">
+      </div>
+      <div class="form-group">
+        <label for="username">שם משתמש</label>
+        <input type="text" id="username" name="username" [(ngModel)]="username"
+               class="form-control" placeholder="הכנס שם משתמש">
+      </div>
+      <div class="form-group">
+        <label for="password">סיסמא</label>
+        <input type="password" id="password" name="password" [(ngModel)]="password"
+               class="form-control" placeholder="הכנס סיסמא">
+      </div>
+      <div class="form-group auth-submit">
+        <button type="submit" class="btn btn-primary btn-block auth-btn">הרשם</button>
+      </div>
+    </form>
   </div>
-  <form (submit)="register()" style="color:white">
-    <div class="form-group col-md-10 col-md-pull-0" dir="rtl">
-      <label for="">אימייל</label>
-      <input type="email" name="email" [(ngModel)]="email" class="form-control" placeholder="הכנס אימייל">
-    </div>
-    <div class="form-group col-md-10 col-md-pull-0" dir="rtl">
-      <label for="">שם משתמש</label>
-      <input type="text" name="username" [(ngModel)]="username" class="form-control" placeholder="הכנס שם משתמש">
-  
-    </div>
-    <div class="form-group col-md-10 col-md-pull-0" dir="rtl">
-      <label for="">סיסמא</label>
-      <input type="password" name="password" [(ngModel)]="password" class="form-control" placeholder="הכנס סיסמא">
-    </div>
-    <div class="form-group col-md-10 col-md-pull-0">
-      <button type="submit" class="btn btn-primary btn-lg">הרשם</button>
-    </div>
-  </form>
+</div>

--- a/angular-src/src/app/register/register.component.ts
+++ b/angular-src/src/app/register/register.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { SiteRegisterServiceService } from "../services/site-register-service.service";
-import { FlashMessagesService } from "angular2-flash-messages";
+import { ToastrService } from "ngx-toastr";
 import { AuthService } from "../services/auth.service";
 import { Router } from "@angular/router";
 @Component({
@@ -15,7 +15,7 @@ export class RegisterComponent implements OnInit {
 
   constructor(
     private siteRegServ:SiteRegisterServiceService,
-    private flashMsg:FlashMessagesService,
+    private toastr:ToastrService,
     private auth:AuthService,
     private router:Router
   ) { }
@@ -31,21 +31,21 @@ export class RegisterComponent implements OnInit {
     
     //requierd fields
     if(!this.siteRegServ.validateRegister(SiteUser)){
-      this.flashMsg.show('אנא מלא את כל השדות!',{ cssClass: 'alert-danger', timeout: 3000 });
+      this.toastr.error('אנא מלא את כל השדות!');
       return false;
     }
     if(!this.siteRegServ.validateEmail(SiteUser.email)){
-      this.flashMsg.show('הכנס מחדש את האימייל!',{ cssClass: 'alert-danger', timeout: 3000 });
+      this.toastr.error('הכנס מחדש את האימייל!');
       return false;
     }
 
     //register Site User
     this.auth.registerSiteUser(SiteUser).subscribe(data=>{
       if(data.success){
-        this.flashMsg.show('נרשמתה בהצלחה',{ cssClass: 'alert-success', timeout: 3000 });
+        this.toastr.success('נרשמתה בהצלחה');
         this.router.navigate(['/login']);
       }else{
-        this.flashMsg.show('לא נרשמתה בהצלחה',{ cssClass: 'alert-danger', timeout: 3000 });
+        this.toastr.error('לא נרשמתה בהצלחה');
         this.router.navigate(['/register']);
       }
     })

--- a/angular-src/src/app/services/http-error-interceptor.service.ts
+++ b/angular-src/src/app/services/http-error-interceptor.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ConnectionBackend, Http, Request, RequestOptions, RequestOptionsArgs, Response } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/observable/throw';
+import { FlashMessagesService } from 'angular2-flash-messages';
+
+@Injectable()
+export class HttpErrorInterceptor extends Http {
+
+  constructor(backend: ConnectionBackend, defaultOptions: RequestOptions, private flashMessages: FlashMessagesService) {
+    super(backend, defaultOptions);
+  }
+
+  request(url: string | Request, options?: RequestOptionsArgs): Observable<Response> {
+    return super.request(url, options).catch(error => this.handleError(error));
+  }
+
+  private handleError(error: any): Observable<any> {
+    const message = !error.status
+      ? 'שגיאת תקשורת: לא ניתן להתחבר לשרת'
+      : 'אירעה שגיאה בשרת, נסו שוב מאוחר יותר';
+    this.flashMessages.show(message, { cssClass: 'alert-danger', timeout: 4000 });
+    return Observable.throw(error);
+  }
+}

--- a/angular-src/src/app/services/http-error-interceptor.service.ts
+++ b/angular-src/src/app/services/http-error-interceptor.service.ts
@@ -3,12 +3,12 @@ import { ConnectionBackend, Http, Request, RequestOptions, RequestOptionsArgs, R
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
-import { FlashMessagesService } from 'angular2-flash-messages';
+import { ToastrService } from 'ngx-toastr';
 
 @Injectable()
 export class HttpErrorInterceptor extends Http {
 
-  constructor(backend: ConnectionBackend, defaultOptions: RequestOptions, private flashMessages: FlashMessagesService) {
+  constructor(backend: ConnectionBackend, defaultOptions: RequestOptions, private toastr: ToastrService) {
     super(backend, defaultOptions);
   }
 
@@ -20,7 +20,7 @@ export class HttpErrorInterceptor extends Http {
     const message = !error.status
       ? 'שגיאת תקשורת: לא ניתן להתחבר לשרת'
       : 'אירעה שגיאה בשרת, נסו שוב מאוחר יותר';
-    this.flashMessages.show(message, { cssClass: 'alert-danger', timeout: 4000 });
+    this.toastr.error(message);
     return Observable.throw(error);
   }
 }

--- a/angular-src/src/app/vanhillequiz/questions/questions.component.css
+++ b/angular-src/src/app/vanhillequiz/questions/questions.component.css
@@ -176,3 +176,15 @@ input.radio:checked ~ .answer-label {
   color: #1F2937;
   font-weight: 600;
 }
+
+@media (max-width: 767px) {
+  .quiz-header { padding: 12px 16px; flex-wrap: wrap; gap: 8px; }
+  .quiz-body { padding: 0 12px 32px; }
+  .question-card { padding: 20px 16px; }
+  .question-media { flex-direction: column; }
+  .question-img { max-width: 100%; }
+  .quiz-nav { flex-direction: column-reverse; }
+  .quiz-nav .btn,
+  .quiz-nav .btn-nav-prev { width: 100%; }
+  .finish-card { padding: 32px 24px; }
+}

--- a/angular-src/src/app/vanhillequiz/questions/questions.component.css
+++ b/angular-src/src/app/vanhillequiz/questions/questions.component.css
@@ -1,73 +1,178 @@
-
-.margin{
-	margin-top: 50px;
-	margin-right:115px; 
-}
-.header{
-    text-decoration: underline;
-    text-align: center;
-	margin-right: 150px;
-	color: white;
-}
-h3{
-	color: white;
-}
-section { clear: both; margin: 0 80px; }
-
-label {   width: 100%;/* SET BTN WIDTH */ border-radius: 3px; border: 1px solid #D1D3D4; color: white }
-
-/* HIDE <input> */
-input.radio:empty { display: none }
-
-/* CUSTOM LABEL */
-input.radio:empty ~ label {
- position: relative;
- float: left;
- font-size: 15px;
- line-height: 2.5em;
- text-indent: 1.25em;
- margin-top: 1em;
- cursor: pointer;
- -webkit-user-select: none;
- -moz-user-select: none;
- -ms-user-select: none;
- user-select: none;
- background-color: #1A948E;
- color: white;
- /* width: 1000px; */
+/* Quiz header row */
+.quiz-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  margin-bottom: 8px;
 }
 
-/* Label, not hovered or checked */
-input.radio:empty ~ label:before {
-	position: absolute;
-	display: block;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	content: '';
-	width: 2.5em;
-	background: #102EB3; /*#D4D1D4;*/
-	border-radius: 3px 0 0 3px;
+.quiz-counter {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #6B7280;
+  letter-spacing: 0.5px;
 }
 
-/* On Hover */
-input.radio:hover:not(:checked) ~ label:before {
-	content:'\2714';
-	text-indent: .9em;
-	color: #C2C2C2;
+/* Timer card */
+.timer-card {
+  background-color: #FF8C42;
+  color: #FFFFFF;
+  border-radius: 12px;
+  padding: 10px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 130px;
+  box-shadow: 0 4px 12px rgba(255, 140, 66, 0.3);
 }
 
-input.radio:hover:not(:checked) ~ label { color: black; }
-
-/* Checked */
-input.radio:checked ~ label:before {
-	content:'\2714';
-	text-indent: .9em;
-	color: #9CE2AE;
-	background-color: #4DCB6D;
+.timer-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.85;
+  margin-bottom: 2px;
 }
 
-input.radio:checked ~ label { color: black; }
+.timer-card countdown,
+.timer-card ::ng-deep .countdown {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #FFFFFF;
+}
 
-/* On Focus */
-input.radio:focus ~ label:before { box-shadow: 0 0 0 3px #999; }
+/* Quiz body */
+.quiz-body {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 24px 48px;
+}
+
+/* Question card */
+.question-card {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 32px;
+  margin-bottom: 24px;
+}
+
+.question-media {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.question-img {
+  max-width: 200px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.question-text {
+  font-size: 1.15rem;
+  font-weight: 500;
+  color: #1F2937;
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* Answer options */
+.answers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.answer-option {
+  display: block;
+}
+
+/* Hide native radio */
+input.radio {
+  display: none;
+}
+
+/* Answer card label */
+input.radio ~ .answer-label {
+  display: block;
+  width: 100%;
+  padding: 14px 20px;
+  border: 1.5px solid #E5E7EB;
+  border-radius: 12px;
+  background-color: #FFFFFF;
+  color: #1F2937;
+  font-size: 1rem;
+  font-weight: 400;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+  margin: 0;
+}
+
+input.radio ~ .answer-label:hover {
+  border-color: #5B7FFF;
+  background-color: #F7F8FD;
+}
+
+input.radio:checked ~ .answer-label {
+  border-color: #5B7FFF;
+  background-color: #EEF2FF;
+  color: #1F2937;
+  font-weight: 500;
+}
+
+/* Navigation buttons */
+.quiz-nav {
+  display: flex;
+  gap: 12px;
+  flex-direction: row-reverse;
+  align-items: center;
+}
+
+.btn-nav-prev {
+  background-color: transparent !important;
+  border: 2px solid #5B7FFF !important;
+  color: #5B7FFF !important;
+  border-radius: 12px !important;
+  font-weight: 500;
+  padding: 8px 20px;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-nav-prev:hover {
+  background-color: #5B7FFF !important;
+  color: #FFFFFF !important;
+}
+
+/* Finish screen */
+.quiz-finish {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 80px 24px;
+}
+
+.finish-card {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 48px 64px;
+  text-align: center;
+}
+
+.finish-icon {
+  width: 64px;
+  height: 64px;
+  background-color: #38C172;
+  border-radius: 50%;
+  color: #FFFFFF;
+  font-size: 2rem;
+  line-height: 64px;
+  margin: 0 auto 24px;
+}
+
+.finish-card h2 {
+  color: #1F2937;
+  font-weight: 600;
+}

--- a/angular-src/src/app/vanhillequiz/questions/questions.component.html
+++ b/angular-src/src/app/vanhillequiz/questions/questions.component.html
@@ -1,56 +1,39 @@
-<div *ngIf="!showFinish" class="row">
-  <!-- <app-timer></app-timer> -->
-  <h2 class=" header">שאלה מס' {{qnumber}}</h2>
-  <div class="card pull-left" dir="rtl" style="background-color: white">
-    <div class="card-header">
-      <h4>זמן שנותר לסיום</h4>
-    </div>
-    <div class="card-body text-center">
-      <countdown [config]="counterConfig" (finished)="calcUser(false)"></countdown>
-    </div>
+<div *ngIf="!showFinish" class="quiz-header" dir="rtl">
+  <span class="quiz-counter">שאלה מס' {{qnumber}}</span>
+  <div class="timer-card">
+    <span class="timer-label">זמן שנותר לסיום</span>
+    <countdown [config]="counterConfig" (finished)="calcUser(false)"></countdown>
   </div>
 </div>
-<div *ngIf="!showFinish" class="margin">
 
-  <div class="row" dir="rtl">
+<div *ngIf="!showFinish" class="quiz-body" dir="rtl">
+  <div class="question-card">
+    <div class="question-media">
+      <img *ngIf="img" class="question-img" src="{{img}}">
+      <h3 class="question-text" [innerHTML]="question"></h3>
+    </div>
 
-    <div>
-      <div class="row">
-        <div class="col-md-4">
-          <img class="media-object" src="{{img}}">
-        </div>
-        <div class="col-md-7">
-          <h3 [innerHTML]="question"></h3>
-        </div>
-      </div>
+    <div class="answers-list">
+      <section *ngFor="let answer of Answers" class="answer-option">
+        <input id={{answer.num}} type="radio" class="radio" [(ngModel)]=radiogroup
+               name="radiogroup" value={{answer.num}} (checked)="radiogroup == answer.num">
+        <label for={{answer.num}} class="answer-label">
+          {{answer.ans}}
+        </label>
+      </section>
     </div>
   </div>
 
-  <!--<div *ngIf="!showFinish" class="col-md-12 pull-right col-md-offset-3">-->
-    <!--<ul>-->
-      <!--<li *ngFor="let answer of Answers" dir="rtl">-->
-        <!--<label for={{answer.num}} dir="rtl">-->
-            <!---->
-        <!--</label>-->
-        <!--<input id={{answer.num}} type="radio" class="radio" [(ngModel)]=radiogroup name="radiogroup">-->
-      <!--</li>-->
-    <!--</ul>-->
-  <!--</div>-->
-  <div *ngIf="!showFinish" class="col-md-12 pull-right col-md-offset-3">
-    <section *ngFor="let answer of Answers" dir="rtl">
-      <input id={{answer.num}} type="radio" class="radio" [(ngModel)]=radiogroup name="radiogroup" value={{answer.num}} (checked)="radiogroup == answer.num">
-      <label for={{answer.num}} dir="rtl">
-        {{answer.ans}}
-      </label>
-    </section>
-  </div>
-  <div class="row col-md-8 pull-left">
+  <div class="quiz-nav">
+    <button id="back" type="button" class="btn btn-nav-prev" (click)="backQuestion()">שאלה קודמת</button>
     <button id="next" type="button" class="btn btn-primary" (click)="saveAnswer()">שאלה הבאה</button>
-    <button id="back" type="button" class="btn btn-danger" (click)="backQuestion()">שאלה קודמת</button>
-    <button *ngIf="finish" id="finish" type="button" class="btn btn-danger" (click)="calcUser(true)">סיים שאלון</button>
+    <button *ngIf="finish" id="finish" type="button" class="btn btn-success" (click)="calcUser(true)">סיים שאלון</button>
   </div>
-
 </div>
-<div *ngIf="showFinish" class="col-md-7 margin" style="color: white" dir="rtl">
-  <h2>סיימת את השאלון, בהצלחה!</h2>
+
+<div *ngIf="showFinish" class="quiz-finish" dir="rtl">
+  <div class="finish-card">
+    <div class="finish-icon">✓</div>
+    <h2>סיימת את השאלון, בהצלחה!</h2>
+  </div>
 </div>

--- a/angular-src/src/app/vanhillequiz/questions/questions.component.ts
+++ b/angular-src/src/app/vanhillequiz/questions/questions.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit, Injectable, AfterViewChecked} from '@angular/core';
 import {QuestionsserviceService} from '../../services/questionsservice.service';
-import {FlashMessagesService} from 'angular2-flash-messages';
+import {ToastrService} from 'ngx-toastr';
 import {Ng4LoadingSpinnerService} from 'ng4-loading-spinner';
 
 @Component({
@@ -28,7 +28,7 @@ export class QuestionsComponent implements OnInit {
 
 
   constructor(private questionService: QuestionsserviceService,
-              private flashmessage: FlashMessagesService,
+              private toastr: ToastrService,
               private spinner: Ng4LoadingSpinnerService) {
 
   }
@@ -69,7 +69,7 @@ export class QuestionsComponent implements OnInit {
           this.hideButtons();
         }
       } else {
-        this.flashmessage.show('שגיאה לא ניתן לעבור לשאלה הבאה', {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error('שגיאה לא ניתן לעבור לשאלה הבאה');
       }
       this.spinner.hide();
     });
@@ -112,7 +112,7 @@ export class QuestionsComponent implements OnInit {
           }
 
         } else {
-          this.flashmessage.show('לא נשמרה התשובה', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('לא נשמרה התשובה');
           return false;
         }
       });
@@ -129,7 +129,7 @@ export class QuestionsComponent implements OnInit {
             return true;
           }
         } else {
-          this.flashmessage.show('לא נשמרה התשובה', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('לא נשמרה התשובה');
           return false;
         }
       });
@@ -146,7 +146,7 @@ export class QuestionsComponent implements OnInit {
             return true;
           }
         } else {
-          this.flashmessage.show('לא נשמרה התשובה', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('לא נשמרה התשובה');
           return false;
         }
       });
@@ -163,7 +163,7 @@ export class QuestionsComponent implements OnInit {
             return true;
           }
         } else {
-          this.flashmessage.show('לא נשמרה התשובה', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('לא נשמרה התשובה');
           return false;
         }
       });
@@ -180,12 +180,12 @@ export class QuestionsComponent implements OnInit {
             return true;
           }
         } else {
-          this.flashmessage.show('לא נשמרה התשובה', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('לא נשמרה התשובה');
           return false;
         }
       });
     } else {
-      this.flashmessage.show('לא נבחרה תשובה', {cssClass: 'alert-danger', timeout: 3000});
+      this.toastr.error('לא נבחרה תשובה');
     }
 
   }
@@ -207,7 +207,7 @@ export class QuestionsComponent implements OnInit {
       if (data.success) {
         this.showFinish = true;
       } else {
-        this.flashmessage.show('לא ניתן לשמור תשובות נכונות של סטודנט', {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error('לא ניתן לשמור תשובות נכונות של סטודנט');
       }
     });
   }

--- a/angular-src/src/app/vanhillequiz/report/class-report/calc-report/calc-report.component.css
+++ b/angular-src/src/app/vanhillequiz/report/class-report/calc-report/calc-report.component.css
@@ -1,7 +1,30 @@
-.header{
-  text-decoration: underline;
-  text-align: center;
-  /* margin-right: 250px; */
-  margin-right: 150px;
-  color: white;
+.header {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-align: right;
+  text-decoration: none;
+  margin-right: 0;
+  margin-bottom: 16px;
+  padding-right: 12px;
+  border-right: 4px solid #5B7FFF;
+}
+
+/* Chart container */
+[style*="background-color: white"] {
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 24px;
+  margin-bottom: 16px;
+}
+
+.button-group {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.button-group .form-control {
+  margin-bottom: 0;
 }

--- a/angular-src/src/app/vanhillequiz/report/class-report/calc-report/calc-report.component.ts
+++ b/angular-src/src/app/vanhillequiz/report/class-report/calc-report/calc-report.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {VanhilereportService} from '../../../../services/vanhilereport.service';
-import {FlashMessagesService} from 'angular2-flash-messages';
+import {ToastrService} from 'ngx-toastr';
 //import {SnotifyService} from 'ng-snotify';
 import {ChartsModule} from 'ng2-charts/ng2-charts';
 
@@ -39,7 +39,7 @@ export class CalcReportComponent implements OnInit {
   tryNumOptions: [any] = [1, 2];
 
   constructor(private reportService: VanhilereportService,
-              private flashMessagesService: FlashMessagesService,) {
+              private toastr: ToastrService,) {
   }
 
   ngOnInit() {
@@ -59,7 +59,7 @@ export class CalcReportComponent implements OnInit {
         //  this.Options = data.resQuiz;
       } else {
         //this.snotifyMessage.error(data.msg, 'שגיאה', {style: 'material'});
-        this.flashMessagesService.show(data.msg, {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error(data.msg);
       }
     });
   }
@@ -70,7 +70,7 @@ export class CalcReportComponent implements OnInit {
   getAllUniqueCourseNum() {
     this.reportService.getAllUniqueCourseNum().subscribe(data => {
       if (!data.success) {
-        this.flashMessagesService.show(data.msg, {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error(data.msg);
       } else {
         this.courseNumOptions = data.result;
       }
@@ -80,7 +80,7 @@ export class CalcReportComponent implements OnInit {
   getCorepondingGroupNums() {
     this.reportService.getCorepondingGroupNums(this.courseNum).subscribe(data => {
       if (!data.success) {
-        this.flashMessagesService.show(data.msg, {cssClass: 'alert-danger', timeout: 3000});
+        this.toastr.error(data.msg);
       } else {
         this.groupNumOptions = data.result;
       }

--- a/angular-src/src/app/vanhillequiz/report/class-report/class-report.component.css
+++ b/angular-src/src/app/vanhillequiz/report/class-report/class-report.component.css
@@ -1,10 +1,19 @@
-.header{
-    text-decoration: underline;
-    text-align: center;
-    /* margin-right: 250px; */
-    margin-right: 150px;
-    color: white;
+.container-fluid {
+  padding: 24px 32px;
 }
-h1,h2{
-    color: white;
+
+.header {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-align: right;
+  text-decoration: none;
+  margin-right: 0;
+  margin-bottom: 24px;
+  padding-right: 16px;
+  border-right: 4px solid #5B7FFF;
+}
+
+h1, h2 {
+  color: #1F2937;
 }

--- a/angular-src/src/app/vanhillequiz/report/class-report/class-report.component.html
+++ b/angular-src/src/app/vanhillequiz/report/class-report/class-report.component.html
@@ -1,12 +1,12 @@
 <div class="container-fluid" dir="rtl">
   <h1 class="header">תוצאות כל הכיתה</h1>
-  <div *ngIf="!showpast" class="row col-md-12 col-md-pull-1">
+  <div *ngIf="!showpast">
     <app-calc-report></app-calc-report>
   </div>
   <div *ngIf="showpast">
     <app-past-present-report></app-past-present-report>
   </div>
-  <button type="button" style="margin-top: 10px" class="col-md-12 col-md-pull-1 btn btn-primary" (click)="showPast()">הצג/הסתר
+  <button type="button" style="margin-top: 10px" class="btn btn-primary btn-block" (click)="showPast()">הצג/הסתר
     השוואת נתונים קודמים
   </button>
 

--- a/angular-src/src/app/vanhillequiz/report/class-report/class-report.component.ts
+++ b/angular-src/src/app/vanhillequiz/report/class-report/class-report.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {VanhilereportService} from '../../../services/vanhilereport.service';
-import {FlashMessagesService} from 'angular2-flash-messages';
+import {ToastrService} from 'ngx-toastr';
 import {ChartsModule} from 'ng2-charts/ng2-charts';
 import set = Reflect.set;
 
@@ -14,7 +14,7 @@ export class ClassReportComponent implements OnInit {
   showpast: boolean = false;
 
   constructor(private reportServise: VanhilereportService,
-              private flashmessage: FlashMessagesService) {
+              private toastr: ToastrService) {
   }
 
   ngOnInit() {

--- a/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/bar-view/bar-view.component.css
+++ b/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/bar-view/bar-view.component.css
@@ -1,7 +1,9 @@
-.header{
-  text-decoration: underline;
-  text-align: center;
-  /* margin-right: 250px; */
-  margin-right: 150px;
-  color: white;
+.header {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-decoration: none;
+  margin-bottom: 12px;
+  padding-right: 12px;
+  border-right: 4px solid #38C172;
 }

--- a/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/past-present-report.component.css
+++ b/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/past-present-report.component.css
@@ -1,7 +1,22 @@
-.header{
-  text-decoration: underline;
-  text-align: center;
-  /* margin-right: 250px; */
-  margin-right: 150px;
-  color: white;
+.header {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-align: right;
+  text-decoration: none;
+  margin-right: 0;
+  margin-bottom: 20px;
+  padding-right: 12px;
+  border-right: 4px solid #5B7FFF;
+}
+
+.button-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  margin-bottom: 16px;
 }

--- a/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/past-present-report.component.html
+++ b/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/past-present-report.component.html
@@ -47,7 +47,7 @@
     <button type="button" class="btn btn-success  btn-block" (click)="findQuizByGroupAndCourseNum('1')">חפש</button>
   </div>
 </div>
-<button type="button" style="margin-top: 10px" class="col-md-12 col-md-pull-1 btn btn-primary" (click)="switchGraphs()">החלף סוג גרף
+<button type="button" style="margin-top: 10px" class="btn btn-primary btn-block" (click)="switchGraphs()">החלף סוג גרף
 </button>
 
 

--- a/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/past-present-report.component.ts
+++ b/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/past-present-report.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {ChartsModule} from 'ng2-charts/ng2-charts';
-import {FlashMessagesService} from 'angular2-flash-messages';
+import {ToastrService} from 'ngx-toastr';
 import {VanhilereportService} from '../../../../services/vanhilereport.service';
 
 @Component({
@@ -29,7 +29,7 @@ export class PastPresentReportComponent implements OnInit {
   courseNum: Number;
 
   constructor(private reportServise: VanhilereportService,
-              private flashmessage: FlashMessagesService) {
+              private toastr: ToastrService) {
   }
 
   ngOnInit() {
@@ -39,7 +39,7 @@ export class PastPresentReportComponent implements OnInit {
   switchGraphs() {
     if (this.courseNumPost === undefined || this.courseNumPre === undefined || this.groupNumPre === undefined
       || this.groupNumPost === undefined) {
-      this.flashmessage.show('אנא בחר את הקבוצות להשוואה לפני מעבר לגרף ברים', {cssClass: 'alert-danger', timeout: 3000});
+      this.toastr.error('אנא בחר את הקבוצות להשוואה לפני מעבר לגרף ברים');
     } else {
       this.showBarGraph = !this.showBarGraph;
     }
@@ -68,7 +68,7 @@ export class PastPresentReportComponent implements OnInit {
     this.reportServise.getAllQuizesDoneInTheLastSemeter().subscribe(data => {
       if (data.success) {
         if (data.quiz.length == 0) {
-          this.flashmessage.show('אין שאלונים שבוצעו בסמסטר האחרון', {cssClass: 'alert-danger', timeout: 3000});
+          this.toastr.error('אין שאלונים שבוצעו בסמסטר האחרון');
         } else if (data.quiz.length == 1) {
           this.courseNumPreOptions = [data.quiz[0].courseNum];
         } else {
@@ -87,7 +87,7 @@ export class PastPresentReportComponent implements OnInit {
           }
         }
       } else {
-        this.flashmessage.show('שגיאה בטעינת שאלונים שבוצעו בסמסטר האחרון', {cssClass: 'alert-danger', timeout: 3000})
+        this.toastr.error('שגיאה בטעינת שאלונים שבוצעו בסמסטר האחרון')
       }
     });
   }
@@ -98,10 +98,7 @@ export class PastPresentReportComponent implements OnInit {
         if (data.success) {
           this.groupNumPreOptions = [data.quiz[0].groupNum];
         } else {
-          this.flashmessage.show('שגיאה במציאת ערכים לתוצאות לפני לשדה של מס קורס', {
-            cssClass: 'alert-danger',
-            timeout: 3000
-          });
+          this.toastr.error('שגיאה במציאת ערכים לתוצאות לפני לשדה של מס קורס');
         }
       });
     }
@@ -112,10 +109,7 @@ export class PastPresentReportComponent implements OnInit {
             this.groupNumPostOptions = [data.quiz[1].groupNum];
           }
         } else {
-          this.flashmessage.show('שגיאה במציאת ערכים לתוצאות אחרי לשדה של מס קורס', {
-            cssClass: 'alert-danger',
-            timeout: 3000
-          });
+          this.toastr.error('שגיאה במציאת ערכים לתוצאות אחרי לשדה של מס קורס');
         }
       });
     }

--- a/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/radar-view/radar-view.component.css
+++ b/angular-src/src/app/vanhillequiz/report/class-report/past-present-report/radar-view/radar-view.component.css
@@ -1,7 +1,9 @@
-.header{
-  text-decoration: underline;
-  text-align: center;
-  /* margin-right: 250px; */
-  margin-right: 150px;
-  color: white;
+.header {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-decoration: none;
+  margin-bottom: 12px;
+  padding-right: 12px;
+  border-right: 4px solid #FF8C42;
 }

--- a/angular-src/src/app/vanhillequiz/report/report.component.css
+++ b/angular-src/src/app/vanhillequiz/report/report.component.css
@@ -1,10 +1,15 @@
-.header{
-    text-decoration: underline;
-    text-align: center;
-    /* margin-right: 250px; */
-    margin-right: 150px;
-    color: white;
+.header {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-align: right;
+  text-decoration: none;
+  margin-right: 0;
+  margin-bottom: 24px;
+  padding-right: 16px;
+  border-right: 4px solid #5B7FFF;
 }
-h1{
-    color: white;
+
+h1 {
+  color: #1F2937;
 }

--- a/angular-src/src/app/vanhillequiz/report/report.component.ts
+++ b/angular-src/src/app/vanhillequiz/report/report.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { VanhilereportService } from "../../services/vanhilereport.service";
-import { FlashMessagesService } from "angular2-flash-messages";
+import { ToastrService } from "ngx-toastr";
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 @Component({
   selector: 'app-report',
@@ -15,7 +15,7 @@ export class ReportComponent implements OnInit {
   // radarChartData: any[] = [{
   // }];
   //
-  constructor(private reportServise: VanhilereportService, private flashmessage: FlashMessagesService) { }
+  constructor(private reportServise: VanhilereportService, private toastr: ToastrService) { }
 
   ngOnInit() {
     // this.reportServise.getUsersLast3Hours().subscribe(data => {

--- a/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.css
+++ b/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.css
@@ -1,10 +1,47 @@
-.header{
-    text-decoration: underline;
-    text-align: center;
-    /* margin-right: 250px; */
-    margin-right: 150px;
-    color: white;
+.allclass {
+  padding: 24px 32px;
 }
-h1{
-    color: white;
+
+.header {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-align: right;
+  text-decoration: none;
+  margin-right: 0;
+  margin-bottom: 24px;
+  padding-right: 16px;
+  border-right: 4px solid #5B7FFF;
+}
+
+h1 {
+  color: #1F2937;
+}
+
+label {
+  color: #1F2937!important;
+  font-size: 0.9rem !important;
+}
+
+.input-append {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.col-md-6 {
+  background-color: #FFFFFF !important;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 24px !important;
+}
+
+.col-md-6 h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1F2937;
+  text-align: center;
+  margin-bottom: 16px;
 }

--- a/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.css
+++ b/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.css
@@ -31,6 +31,61 @@ label {
   margin-bottom: 16px;
 }
 
+.report-card {
+  background-color: #FFFFFF;
+  border-radius: 16px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  padding: 20px 24px;
+  margin-bottom: 20px;
+}
+
+.report-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1F2937;
+  margin: 0 0 16px;
+  text-align: right;
+}
+
+.report-card-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.report-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 200px;
+}
+
+.report-field ::ng-deep dp-date-picker,
+.report-field ::ng-deep .dp-input-container {
+  width: 100%;
+  display: block;
+}
+
+.report-field label {
+  font-size: 0.85rem !important;
+  color: #6B7280 !important;
+  font-weight: 500;
+  margin: 0 !important;
+}
+
+.report-card-btn {
+  height: 42px;
+  padding: 0 24px;
+  font-weight: 600;
+}
+
+.report-select {
+  flex: 1;
+  min-width: 200px;
+  margin-bottom: 0;
+}
+
 .col-md-6 {
   background-color: #FFFFFF !important;
   border-radius: 20px;

--- a/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.html
+++ b/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.html
@@ -2,26 +2,30 @@
   <h1 class="header">תוצאה לפי סטודנט</h1>
   <br>
   <div class="form-group">
-    <div class="input-append">
-      <label style="color:white;font-size: 18px"> תאריך התחלה
-        <dp-date-picker style="color:black " placeholder="enter a start date" [(ngModel)]="sDate" theme="dp-material"></dp-date-picker>
-      </label>
-      <label style="color:white;font-size: 18px"> תאריך סיום
-          <dp-date-picker style="color:black " placeholder="enter a finish date" [(ngModel)]="fDate" theme="dp-material"></dp-date-picker>
-      </label>
-      <button type="button" class="btn btn-success pull-left" (click)="findStudentsBetweenDates()">חפש</button>
-    </div>
-    <br>
-    <div class="input-append">
-      <label style="color:white;font-size: 18px">ת.ז של הסטודנט</label>
-      <select name="selectID" class="form-control" [(ngModel)]="selectID" (change)="findCorrectAnswerData()">
-        <option *ngFor="let op of Options" [value]="op.ID">{{op.ID}}</option>
-      </select>
-      <button type="button" class="btn btn-danger pull-left" (click)="clearSelection()">נקה בחירה</button>
+    <div class="report-card">
+      <h3 class="report-card-title">חיפוש לפי טווח תאריכים</h3>
+      <div class="report-card-row">
+        <div class="report-field">
+          <label>תאריך התחלה</label>
+          <dp-date-picker [config]="dateConfig" placeholder="בחרו תאריך התחלה" [(ngModel)]="sDate" theme="dp-material"></dp-date-picker>
+        </div>
+        <div class="report-field">
+          <label>תאריך סיום</label>
+          <dp-date-picker [config]="dateConfig" placeholder="בחרו תאריך סיום" [(ngModel)]="fDate" theme="dp-material"></dp-date-picker>
+        </div>
+        <button type="button" class="btn btn-success report-card-btn" (click)="findStudentsBetweenDates()">חפש</button>
+      </div>
     </div>
 
-    <br>
-    <br>
+    <div class="report-card">
+      <h3 class="report-card-title">חיפוש לפי ת.ז של הסטודנט</h3>
+      <div class="report-card-row">
+        <select name="selectID" class="form-control report-select" [(ngModel)]="selectID" (change)="findCorrectAnswerData()">
+          <option *ngFor="let op of Options" [value]="op.ID">{{op.ID}}</option>
+        </select>
+        <button type="button" class="btn btn-danger report-card-btn" (click)="clearSelection()">נקה בחירה</button>
+      </div>
+    </div>
     <div class="row" style="margin-left:5px">
       <div class="col-md-6" *ngIf="showHideSecondChart()" style="display: block;background-color: white  ">
         <h3 style="text-align: center">תוצאות אחרי</h3>

--- a/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.html
+++ b/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.html
@@ -1,7 +1,7 @@
 <div class="row allclass" dir="rtl">
   <h1 class="header">תוצאה לפי סטודנט</h1>
   <br>
-  <div class="form-group col-md-11 col-md-pull-1">
+  <div class="form-group">
     <div class="input-append">
       <label style="color:white;font-size: 18px"> תאריך התחלה
         <dp-date-picker style="color:black " placeholder="enter a start date" [(ngModel)]="sDate" theme="dp-material"></dp-date-picker>

--- a/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.ts
+++ b/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { VanhilereportService } from "../../../services/vanhilereport.service";
-import { FlashMessagesService } from "angular2-flash-messages";
+import { ToastrService } from "ngx-toastr";
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 
 @Component({
@@ -23,7 +23,7 @@ export class StudentReportComponent implements OnInit {
 
   constructor(
     private reportServise: VanhilereportService,
-    private flashmessage: FlashMessagesService
+    private toastr: ToastrService
   ) { }
 
   ngOnInit() {
@@ -31,7 +31,7 @@ export class StudentReportComponent implements OnInit {
       if (data.success) {
         this.Options = data.users;
       } else {
-        this.flashmessage.show('משהו קרה', { cssClass: 'alert-danger', timeout: 3000 });
+        this.toastr.error('משהו קרה');
       }
     });
   }
@@ -111,7 +111,7 @@ export class StudentReportComponent implements OnInit {
             this.barChartData1 = [{ data: data.user[0].correctAperdif1, label: this.selectID }];
           }
         }else{
-          this.flashmessage.show('לא נמצאו תשובות של הסטונדט בעל ת.ז' + this.selectID,{cssClass: 'alert-danger', timeout: 3000 })
+          this.toastr.error('לא נמצאו תשובות של הסטונדט בעל ת.ז' + this.selectID)
           return false;
         }
         //console.log(JSON.stringify(data))
@@ -127,29 +127,29 @@ export class StudentReportComponent implements OnInit {
         // }
 
       } else {
-        this.flashmessage.show('שגיאה', { cssClass: 'alert-danger', timeout: 3000 })
+        this.toastr.error('שגיאה')
       }
     });
   };
 
   findStudentsBetweenDates() {
     if (this.sDate > this.fDate) {
-      this.flashmessage.show("שגיאה! תאריך סיום לפני תאריך התחלה", { cssClass: 'alert-danger', timeout: 3000 })
+      this.toastr.error("שגיאה! תאריך סיום לפני תאריך התחלה")
     } else {
       if (this.sDate == null || this.fDate == null) {
-        this.flashmessage.show("אנא מלא את גם תאריך התחלה וגם תאריך סיום", { cssClass: 'alert-danger', timeout: 3000 })
+        this.toastr.error("אנא מלא את גם תאריך התחלה וגם תאריך סיום")
       } else {
         this.reportServise.getStudentsBetweenDates(this.sDate, this.fDate).subscribe(data => {
           if (data.success) {
             if (data.students.length == 0) {
-              this.flashmessage.show("אין סטודנטים שעשו את השאלון בתאריכים שביקשת", { cssClass: 'alert-danger', timeout: 3000 })
+              this.toastr.error("אין סטודנטים שעשו את השאלון בתאריכים שביקשת")
             } else {
-              this.flashmessage.show("נמצאו סטודנטים מתאים אנא בחר אחד", { cssClass: 'alert-success', timeout: 3000 })
+              this.toastr.success("נמצאו סטודנטים מתאים אנא בחר אחד")
               this.Options = data.students;
               //console.log(this.Options)
             }
           } else {
-            this.flashmessage.show(data.msg, { cssClass: 'alert-danger', timeout: 3000 })
+            this.toastr.error(data.msg)
           }
 
         });

--- a/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.ts
+++ b/angular-src/src/app/vanhillequiz/report/student-report/student-report.component.ts
@@ -2,6 +2,15 @@ import { Component, OnInit } from '@angular/core';
 import { VanhilereportService } from "../../../services/vanhilereport.service";
 import { ToastrService } from "ngx-toastr";
 import { ChartsModule } from 'ng2-charts/ng2-charts';
+import * as moment from 'moment';
+import 'moment/locale/he';
+
+// ng2-date-picker's DatePickerService.getDayConfigService() whitelists which config
+// keys reach the day-calendar, and it drops weekDayFormatter (monthFormatter survives,
+// which is why the month label below is Hebrew but a custom weekday formatter never
+// would be). weekDayFormat (a moment format token, not a function) does survive, so
+// the weekday header is localized via moment's locale instead.
+moment.locale('he');
 
 @Component({
   selector: 'app-student-report',
@@ -20,6 +29,17 @@ export class StudentReportComponent implements OnInit {
   showSecondChart: Boolean = false;
   sDate: Date;
   fDate: Date;
+
+  private static readonly hebrewMonths = [
+    'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני',
+    'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
+  ];
+
+  dateConfig = {
+    firstDayOfWeek: 'su' as any,
+    weekDayFormat: 'ddd',
+    monthFormatter: (month: any) => `${StudentReportComponent.hebrewMonths[month.month()]} ${month.year()}`
+  };
 
   constructor(
     private reportServise: VanhilereportService,

--- a/angular-src/src/app/vanhillequiz/vanhileform/vanhileform.component.css
+++ b/angular-src/src/app/vanhillequiz/vanhileform/vanhileform.component.css
@@ -1,6 +1,37 @@
-.margin{
-    margin-right: 75px;
+.auth-page {
+  display: flex;
+  justify-content: center;
+  padding: 32px 16px 48px;
 }
-h2, label{
-    color: white;
+
+.auth-card {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  padding: 40px;
+  width: 100%;
+  max-width: 480px;
+}
+
+.auth-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #1F2937;
+  margin-bottom: 28px;
+  margin-top: 0;
+  text-align: center;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.auth-submit {
+  margin-top: 8px;
+}
+
+.auth-btn {
+  height: 46px;
+  font-size: 1rem;
+  font-weight: 600;
 }

--- a/angular-src/src/app/vanhillequiz/vanhileform/vanhileform.component.html
+++ b/angular-src/src/app/vanhillequiz/vanhileform/vanhileform.component.html
@@ -1,28 +1,22 @@
-<div class="margin">
-  <h2 class="page-header margin text-center" dir="rtl">פרטים אישיים</h2>
-  <form (submit)="startQuiz()">
-    <!-- <div class="form-group col-md-9 col-md-offset-1" dir="rtl">
-      <label for="">שם פרטי</label>
-      <input type="text" [(ngModel)]="Fname" name="Fname" class="form-control" placeholder="הכנס שם פרטי בלבד">
-    </div>
-    <div class="form-group col-md-9 col-md-offset-1" dir="rtl">
-      <label for="">שם משפחה</label>
-      <input type="text" [(ngModel)]="Lname" name="Lname" class="form-control" placeholder="הכנס שם מפחה בלבד">
-    </div> -->
-    <div class="form-group col-md-9 col-md-offset-1" dir="rtl">
-      <label for="">ת.ז</label>
-      <input type="number" [(ngModel)]="ID" name="ID" class="form-control" placeholder="הכנס ת.ז כולל ספרת ביקורת">
-    </div>
-    <div class="form-group col-md-9 col-md-offset-1" dir="rtl">
-      <label for="">מס' קורס</label>
-      <input type="number" [(ngModel)]="courseNum" name="courseNum" class="form-control" placeholder="הכנס את מס' הקורס">
-    </div>
-    <div class="form-group col-md-9 col-md-offset-1" dir="rtl">
-      <label for="">קבוצת לימוד</label>
-      <input type="number" [(ngModel)]="groupNum" name="groupNum" class="form-control" placeholder="הכנס את מס' קבוצת לימוד">
-    </div>
-    <div class="form-group col-md-9 col-md-offset-1" >
-      <button type="submit" class="btn btn-primary btn-lg">התחל שאלון</button>
-    </div>
-  </form>
+<div class="auth-page">
+  <div class="auth-card" dir="rtl">
+    <h2 class="auth-title">פרטים אישיים</h2>
+    <form (submit)="startQuiz()">
+      <div class="form-group">
+        <label>ת.ז</label>
+        <input type="number" [(ngModel)]="ID" name="ID" class="form-control" placeholder="הכנס ת.ז כולל ספרת ביקורת">
+      </div>
+      <div class="form-group">
+        <label>מס' קורס</label>
+        <input type="number" [(ngModel)]="courseNum" name="courseNum" class="form-control" placeholder="הכנס את מס' הקורס">
+      </div>
+      <div class="form-group">
+        <label>קבוצת לימוד</label>
+        <input type="number" [(ngModel)]="groupNum" name="groupNum" class="form-control" placeholder="הכנס את מס' קבוצת לימוד">
+      </div>
+      <div class="form-group auth-submit">
+        <button type="submit" class="btn btn-primary btn-block auth-btn">התחל שאלון</button>
+      </div>
+    </form>
+  </div>
 </div>

--- a/angular-src/src/app/vanhillequiz/vanhileform/vanhileform.component.ts
+++ b/angular-src/src/app/vanhillequiz/vanhileform/vanhileform.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { VanhileformService } from "../../services/vanhileform.service";
-import { FlashMessagesService } from "angular2-flash-messages";
+import { ToastrService } from "ngx-toastr";
 import { Ng4LoadingSpinnerService } from 'ng4-loading-spinner';
 
 
@@ -18,7 +18,7 @@ export class VanhileformComponent implements OnInit {
   groupNum: Number;
   @Output() showvnahileform: EventEmitter<Boolean> = new EventEmitter<Boolean>();
 
-  constructor(private vanhileformservice: VanhileformService, private flashmessage: FlashMessagesService,private spinner: Ng4LoadingSpinnerService) { }
+  constructor(private vanhileformservice: VanhileformService, private toastr: ToastrService,private spinner: Ng4LoadingSpinnerService) { }
 
   ngOnInit() {
   }
@@ -34,12 +34,12 @@ export class VanhileformComponent implements OnInit {
     this.spinner.show();
     //required fields
     if (!this.vanhileformservice.validateForm(user)) {
-      this.flashmessage.show('מלא את כל השדות', { cssClass: 'alert-danger', timeout: 3000 });
+      this.toastr.error('מלא את כל השדות');
       return false;
     }
     //validate ID length
     if (!this.vanhileformservice.validateID(user.ID)) {
-      this.flashmessage.show('ת.ז שהכנסת הוא קצר או ארוך מידי אנא בדוק שנית!', { cssClass: 'alert-danger', timeout: 3000 });
+      this.toastr.error('ת.ז שהכנסת הוא קצר או ארוך מידי אנא בדוק שנית!');
       return false;
     }
     //check if user exists
@@ -49,10 +49,10 @@ export class VanhileformComponent implements OnInit {
         this.vanhileformservice.createUser(user).subscribe(data => {
           this.spinner.hide();
           if (!data.success) {
-            this.flashmessage.show('לא קיים משתמש כזה אך קרה שגיאה שגיאה', { cssClass: 'alert-danger', timeout: 3000 });
+            this.toastr.error('לא קיים משתמש כזה אך קרה שגיאה שגיאה');
             return false;
           } else {
-            this.flashmessage.show('נרשמת בהצלחה', { cssClass: 'alert-success', timeout: 3000 });
+            this.toastr.success('נרשמת בהצלחה');
             localStorage.setItem('User', user.ID.toString());
             localStorage.setItem('tryNum', "1");
             //hide form
@@ -62,7 +62,7 @@ export class VanhileformComponent implements OnInit {
         });
       } else {
         if (data.user[0].Answers1.length == 0) {
-          this.flashmessage.show('נרשמת בהצלחה', { cssClass: 'alert-success', timeout: 3000 });
+          this.toastr.success('נרשמת בהצלחה');
           localStorage.setItem('User', user.ID.toString());
           localStorage.setItem('tryNum', "1");
           //hide form
@@ -70,14 +70,14 @@ export class VanhileformComponent implements OnInit {
           return true;
         } else
           if (data.user[0].Answers1.length > 0 && data.user[0].Answers2.length < 25 && data.user[0].correctAperdif1.length == 0) {
-            this.flashmessage.show('היית באמצע השאלון (ניסיון 1) ויצאת, השאלון יתחיל מהתחלה!', { cssClass: 'alert-danger', timeout: 5000 });
+            this.toastr.error('היית באמצע השאלון (ניסיון 1) ויצאת, השאלון יתחיל מהתחלה!', undefined, { timeOut: 5000 });
             this.vanhileformservice.nullifyAnswers(user.ID, 1).subscribe(data => {
               if (data.success) {
                 localStorage.setItem('User', data.student.ID.toString());
                 localStorage.setItem('tryNum', "1");
                 this.showvnahileform.emit(false);
               } else {
-                this.flashmessage.show('שגיאה בהתחלת שאלון מחדש (ניסיון 1). אנא נסה שנית',{cssClass:'alert-danger',timeout:3000});
+                this.toastr.error('שגיאה בהתחלת שאלון מחדש (ניסיון 1). אנא נסה שנית');
                 return false;
               }
             })
@@ -92,7 +92,7 @@ export class VanhileformComponent implements OnInit {
                   this.showvnahileform.emit(false);
                   return true;
                 }else{
-                  this.flashmessage.show(data.msg,{cssClass:'alert-danger',timeout:3000});
+                  this.toastr.error(data.msg);
                   return false;
                 }
               })
@@ -101,24 +101,24 @@ export class VanhileformComponent implements OnInit {
               
             } else
               if (data.user[0].Answers2.length > 0 && data.user[0].Answers2.length < 25 && data.user[0].correctAperdif2.length == 0) {
-                this.flashmessage.show('היית באמצע השאלון (ניסיון 2) ויצאת, השאלון יתחיל מהתחלה!', { cssClass: 'alert-danger', timeout: 5000 });
+                this.toastr.error('היית באמצע השאלון (ניסיון 2) ויצאת, השאלון יתחיל מהתחלה!', undefined, { timeOut: 5000 });
                 this.vanhileformservice.nullifyAnswers(user.ID, 2).subscribe(data => {
                   if (data.success) {
                     localStorage.setItem('User', data.student.ID.toString());
                     localStorage.setItem('tryNum', "2");
                     this.showvnahileform.emit(false);
                   } else {
-                    this.flashmessage.show('שגיאה בהתחלת שאלון מחדש (ניסיון 2). אנא נסה שנית',{cssClass:'alert-danger',timeout:3000});
+                    this.toastr.error('שגיאה בהתחלת שאלון מחדש (ניסיון 2). אנא נסה שנית');
                     return false;
                   }
                 })
                 //return false;
               }else{
-                this.flashmessage.show('עשית את השאלון פעמיים, לא ניתן לבצע את השאלון שוב, אנא פנה למרצה',{cssClass:'alert-danger',timeout:3000});
+                this.toastr.error('עשית את השאלון פעמיים, לא ניתן לבצע את השאלון שוב, אנא פנה למרצה');
                 return false;
               }
           }
-        // this.flashmessage.show('קיים משתמש עם ת.ז זהה', { cssClass: 'alert-danger', timeout: 3000 });
+        // this.toastr.error('קיים משתמש עם ת.ז זהה');
         // return false;
       }
     })

--- a/angular-src/src/app/vanhillequiz/vanhillequiz.component.css
+++ b/angular-src/src/app/vanhillequiz/vanhillequiz.component.css
@@ -1,10 +1,13 @@
-.header{
-    text-decoration: underline;
-    text-align: center;
-    /* margin-right: 250px; */
-    margin-right: 150px;
-    color: white;
+.header {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #1F2937;
+  text-align: center;
+  text-decoration: none;
+  margin-bottom: 8px;
+  margin-right: 0;
 }
-.margin{
-    margin-top: 30px;
+
+.margin {
+  margin-top: 24px;
 }

--- a/angular-src/src/index.html
+++ b/angular-src/src/index.html
@@ -16,9 +16,6 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
 
-  <!-- Optional theme -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp"
-    crossorigin="anonymous">
   <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
   <!-- Latest compiled and minified JavaScript -->

--- a/angular-src/src/index.html
+++ b/angular-src/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Qapp</title>
+  <title>זווית</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/angular-src/src/index.html
+++ b/angular-src/src/index.html
@@ -9,6 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
+  <!-- Rubik font — Hebrew + Latin subsets -->
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap&subset=hebrew,latin" rel="stylesheet">
+
   <!-- Latest compiled and minified CSS -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -24,16 +27,6 @@
   <script src="../Client/node_modules/chart.js/src/chart.js" crossorigin="anonymous"></script>
   <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
   <script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
-  <style>
-    body {
-      background-image: url("./assets/background.jpg");
-      background-repeat:  repeat;
-
-      height: 1080px;
-      background-position: center;
-      background-size: cover;
-    }
-  </style>
 </head>
 
 <body>

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -142,8 +142,8 @@ a:hover {
   border: 1.5px solid var(--color-border) !important;
   color: var(--color-text);
   background-color: var(--color-surface);
-  font-size: 1rem;
-  padding: 10px 14px;
+  font-size: 1.05rem;
+  padding: 11px 14px;
   height: auto !important;
   transition: border-color 0.18s ease, box-shadow 0.18s ease;
 }
@@ -156,7 +156,7 @@ a:hover {
 label {
   font-family: var(--font);
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   color: var(--color-text-muted);
   margin-bottom: 4px;
 }

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -44,12 +44,16 @@
   box-sizing: border-box;
 }
 
+html {
+  font-size: 18px;
+}
+
 body {
   margin: 0;
   font-family: var(--font);
   background-color: var(--color-bg);
   color: var(--color-text);
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1.6;
   background-image: none !important;
   min-height: 100vh;

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -1,1 +1,279 @@
-/* You can add global styles to this file, and also import other style files */
+/* =====================================================
+   VanHille Design System — CSS Custom Properties
+   ===================================================== */
+
+:root {
+  /* Colors */
+  --color-primary:        #5B7FFF;
+  --color-primary-dark:   #3D5FE0;
+  --color-secondary:      #38C172;
+  --color-secondary-dark: #28A05A;
+  --color-accent:         #FF8C42;
+  --color-danger:         #EF4444;
+
+  --color-bg:             #F7F8FD;
+  --color-surface:        #FFFFFF;
+  --color-border:         #E5E7EB;
+
+  --color-text:           #1F2937;
+  --color-text-muted:     #6B7280;
+
+  --color-primary-light:  #EEF2FF;
+  --color-hover-row:      #F0F4FF;
+
+  /* Typography */
+  --font: 'Rubik', Arial, sans-serif;
+
+  /* Border radius */
+  --radius-sm:   6px;
+  --radius-md:   12px;
+  --radius-lg:   20px;
+  --radius-pill: 999px;
+
+  /* Shadows */
+  --shadow-subtle: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md:     0 4px 16px rgba(0, 0, 0, 0.10);
+  --shadow-lg:     0 8px 24px rgba(0, 0, 0, 0.14);
+}
+
+/* =====================================================
+   Global Reset & Base
+   ===================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-size: 16px;
+  line-height: 1.6;
+  background-image: none !important;
+  min-height: 100vh;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font);
+  color: var(--color-text);
+}
+
+h1 { font-size: 2rem;   font-weight: 700; }
+h2 { font-size: 1.6rem; font-weight: 600; }
+h3 { font-size: 1.3rem; font-weight: 600; }
+
+a {
+  color: var(--color-primary);
+}
+a:hover {
+  color: var(--color-primary-dark);
+}
+
+/* =====================================================
+   Bootstrap 3 Global Overrides
+   ===================================================== */
+
+/* --- Buttons --- */
+.btn {
+  font-family: var(--font);
+  font-weight: 500;
+  border-radius: var(--radius-md) !important;
+  transition: background-color 0.18s ease, box-shadow 0.18s ease, transform 0.1s ease;
+  border: none;
+  padding: 8px 20px;
+  font-size: 0.95rem;
+}
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn-primary {
+  background-color: var(--color-primary) !important;
+  border-color: var(--color-primary) !important;
+  color: #fff !important;
+}
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: var(--color-primary-dark) !important;
+  border-color: var(--color-primary-dark) !important;
+  box-shadow: 0 4px 12px rgba(91, 127, 255, 0.35) !important;
+}
+
+.btn-success {
+  background-color: var(--color-secondary) !important;
+  border-color: var(--color-secondary) !important;
+  color: #fff !important;
+}
+.btn-success:hover,
+.btn-success:focus {
+  background-color: var(--color-secondary-dark) !important;
+  border-color: var(--color-secondary-dark) !important;
+}
+
+.btn-danger {
+  background-color: var(--color-danger) !important;
+  border-color: var(--color-danger) !important;
+  color: #fff !important;
+}
+.btn-danger:hover,
+.btn-danger:focus {
+  background-color: #DC2626 !important;
+  border-color: #DC2626 !important;
+}
+
+.btn-default {
+  background-color: var(--color-surface) !important;
+  border: 2px solid var(--color-border) !important;
+  color: var(--color-text) !important;
+}
+.btn-default:hover {
+  border-color: var(--color-primary) !important;
+  color: var(--color-primary) !important;
+  background-color: var(--color-primary-light) !important;
+}
+
+/* --- Form Controls --- */
+.form-control {
+  font-family: var(--font);
+  border-radius: var(--radius-sm) !important;
+  border: 1.5px solid var(--color-border) !important;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  font-size: 1rem;
+  padding: 10px 14px;
+  height: auto !important;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+.form-control:focus {
+  border-color: var(--color-primary) !important;
+  box-shadow: 0 0 0 3px rgba(91, 127, 255, 0.18) !important;
+  outline: none;
+}
+
+label {
+  font-family: var(--font);
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  margin-bottom: 4px;
+}
+
+/* --- Jumbotron --- */
+.jumbotron {
+  background-color: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+/* --- Modals --- */
+.modal-content {
+  border-radius: var(--radius-lg) !important;
+  box-shadow: var(--shadow-lg) !important;
+  border: none !important;
+  overflow: hidden;
+}
+.modal-header {
+  border-bottom: 1px solid var(--color-border);
+  padding: 20px 24px;
+}
+.modal-header .modal-title {
+  font-family: var(--font);
+  font-weight: 600;
+  color: var(--color-text);
+}
+.modal-body {
+  padding: 24px;
+}
+.modal-footer {
+  border-top: 1px solid var(--color-border);
+  padding: 16px 24px;
+}
+
+/* --- Dropdowns --- */
+.dropdown-menu {
+  border-radius: var(--radius-md) !important;
+  box-shadow: var(--shadow-md) !important;
+  border: 1px solid var(--color-border) !important;
+  padding: 6px !important;
+  font-family: var(--font);
+}
+.dropdown-menu > li > a {
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  color: var(--color-text);
+  font-weight: 500;
+  transition: background-color 0.15s ease;
+}
+.dropdown-menu > li > a:hover {
+  background-color: var(--color-hover-row) !important;
+  color: var(--color-primary);
+}
+
+/* --- Tables --- */
+.table {
+  font-family: var(--font);
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.table > thead > tr > th {
+  font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  border-bottom: 2px solid var(--color-border);
+  padding: 12px 16px;
+  background-color: var(--color-bg);
+}
+.table > tbody > tr > td {
+  padding: 12px 16px;
+  border-top: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+.table > tbody > tr:hover > td {
+  background-color: var(--color-hover-row);
+}
+
+/* --- Panels (Bootstrap 3) --- */
+.panel {
+  border-radius: var(--radius-lg) !important;
+  box-shadow: var(--shadow-md) !important;
+  border: none !important;
+}
+.panel-heading {
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0 !important;
+  font-family: var(--font);
+  font-weight: 600;
+}
+
+/* --- Alerts --- */
+.alert {
+  border-radius: var(--radius-md) !important;
+  border: none !important;
+  font-family: var(--font);
+  font-weight: 500;
+}
+
+/* --- Badges --- */
+.badge {
+  border-radius: var(--radius-pill) !important;
+  font-family: var(--font);
+  font-weight: 600;
+  font-size: 0.75rem;
+  padding: 4px 10px;
+}
+
+/* --- Nav tabs --- */
+.nav-tabs > li > a {
+  font-family: var(--font);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0 !important;
+}
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover {
+  color: var(--color-primary);
+  border-color: var(--color-border) var(--color-border) transparent;
+}

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -285,6 +285,40 @@ label {
 }
 
 /* =====================================================
+   ng2-date-picker (RTL support)
+   Its own component uses ViewEncapsulation.None, so its classes are
+   genuinely global — overrides here, not in a component stylesheet.
+   ===================================================== */
+
+.dp-picker-input {
+  width: 100% !important;
+  height: 42px !important;
+  font-family: var(--font);
+  font-size: 1rem !important;
+  text-align: right;
+  direction: rtl;
+  border: 1.5px solid var(--color-border) !important;
+  border-radius: var(--radius-sm) !important;
+  padding: 0 14px;
+  box-sizing: border-box;
+}
+.dp-picker-input:focus {
+  border-color: var(--color-primary) !important;
+  outline: none;
+}
+
+/* The nav buttons' left/right containers and chevron shapes are hardcoded (not
+   RTL-aware). Under an inherited dir="rtl", the containers swap visual sides but
+   keep their original chevron rotation, so "previous" ends up pointing the same
+   way as "next". Swap the chevron rotation so each arrow matches its new side. */
+dp-calendar-nav .dp-calendar-nav-left::before {
+  transform: rotate(45deg) !important;
+}
+dp-calendar-nav .dp-calendar-nav-right::before {
+  transform: rotate(-135deg) !important;
+}
+
+/* =====================================================
    Responsive Utilities
    ===================================================== */
 

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -278,3 +278,34 @@ label {
   color: var(--color-primary);
   border-color: var(--color-border) var(--color-border) transparent;
 }
+
+/* =====================================================
+   Responsive Utilities
+   ===================================================== */
+
+/* Scrollable table wrapper */
+.table-responsive-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Mobile typography scale */
+@media (max-width: 767px) {
+  h1 { font-size: 1.6rem; }
+  h2 { font-size: 1.3rem; }
+  h3 { font-size: 1.1rem; }
+
+  /* Forms full-width on mobile */
+  .form-control { font-size: 16px; } /* prevents iOS zoom on focus */
+
+  /* Modals full-width on mobile */
+  .modal-dialog { margin: 8px; }
+  .modal-content { border-radius: 16px !important; }
+
+  /* Stack button groups */
+  .btn-group { display: flex; flex-direction: column; gap: 8px; }
+  .btn-group > .btn { border-radius: var(--radius-md) !important; }
+
+  /* Tables scroll on mobile */
+  .table-responsive { border: none !important; }
+}

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -45,6 +45,7 @@
 }
 
 body {
+  margin: 0;
   font-family: var(--font);
   background-color: var(--color-bg);
   color: var(--color-text);

--- a/angular-src/src/styles.css
+++ b/angular-src/src/styles.css
@@ -52,6 +52,7 @@ body {
   line-height: 1.6;
   background-image: none !important;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/docs/superpowers/specs/2026-07-22-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-22-ui-redesign-design.md
@@ -1,0 +1,182 @@
+# UI Redesign Design Spec — VanHille Math Education Platform
+
+**Date:** 2026-07-22
+**Scope:** Full visual redesign of all pages/components
+**Stack:** Angular 5, Bootstrap 3.3.7, component-scoped CSS
+**Audience:** Students and teachers (both)
+**Style direction:** Friendly academic — warm, approachable, professional
+
+---
+
+## 1. Design System Foundation
+
+### Color Palette
+
+| Role | Name | Hex |
+|------|------|-----|
+| Primary | Warm royal blue | `#5B7FFF` |
+| Secondary | Fresh mint green | `#38C172` |
+| Accent | Warm amber | `#FF8C42` |
+| Background | Soft lavender-gray | `#F7F8FD` |
+| Surface | White | `#FFFFFF` |
+| Border | Light gray | `#E5E7EB` |
+| Text primary | Deep navy | `#1F2937` |
+| Text secondary | Muted gray | `#6B7280` |
+| Primary dark | Hover state | `#3D5FE0` |
+| Secondary dark | Hover state | `#28A05A` |
+| Danger | Red for destructive actions | `#EF4444` |
+
+### Typography
+
+- **Font family:** Rubik (Google Fonts), loaded with Hebrew + Latin subsets
+- **Weights loaded:** 400, 500, 600, 700
+- **Base size:** 16px
+- **Scale:**
+  - `h1`: 2rem / 700
+  - `h2`: 1.6rem / 600
+  - `h3`: 1.3rem / 600
+  - Body: 1rem / 400
+  - Labels/UI text: 1rem / 500
+  - Small/meta: 0.875rem / 400
+
+### Spacing
+
+- Base unit: `8px`
+- Common values: `8`, `12`, `16`, `24`, `32`, `48`, `64`px
+
+### Shape & Elevation
+
+| Name | Border Radius | Usage |
+|------|---------------|-------|
+| `sm` | `6px` | Inputs, badges, small buttons |
+| `md` | `12px` | Buttons, form cards, table rows |
+| `lg` | `20px` | Content cards, modals |
+| `pill` | `999px` | Tags, status indicators |
+
+| Name | Box Shadow | Usage |
+|------|-----------|-------|
+| Subtle | `0 1px 3px rgba(0,0,0,0.08)` | Hover states |
+| Medium | `0 4px 16px rgba(0,0,0,0.10)` | Cards |
+| Strong | `0 8px 24px rgba(0,0,0,0.14)` | Modals, dropdowns |
+
+### CSS Implementation
+
+All tokens are defined as CSS custom properties in `angular-src/src/styles.css` (currently empty). Bootstrap 3 global overrides are also written there. Component `.css` files reference these variables for all design decisions.
+
+---
+
+## 2. Global Bootstrap 3 Overrides
+
+Applied in `styles.css`:
+
+- `body`: Rubik font, `#F7F8FD` background, `#1F2937` text
+- `.btn`: `12px` radius, Rubik 500, smooth transition
+- `.btn-primary`: `#5B7FFF` background, white text, `#3D5FE0` hover
+- `.btn-success`: `#38C172` background, `#28A05A` hover
+- `.btn-danger`: `#EF4444` background
+- `.form-control`: `6px` radius, `#E5E7EB` border, blue focus ring (`#5B7FFF`)
+- `.jumbotron`: Remove default gray, reset padding (individual components override)
+- `.modal-content`: `20px` radius, strong shadow
+- `.dropdown-menu`: `12px` radius, medium shadow
+- `.table > tbody > tr:hover`: `#F0F4FF` background
+
+---
+
+## 3. Component Designs
+
+### 3.1 Navbar (`navbar/navbar.component.css`)
+
+- Background: `#1F2937` (deep navy)
+- Nav links: Rubik 500, `#D1D5DB`, white on hover
+- Active link: colored left-border `4px solid #5B7FFF` (right-border for RTL)
+- Brand text: `#FFFFFF`, Rubik 700
+- Dropdown: `#FFFFFF` background, `12px` radius, medium shadow
+- Dropdown items: `#1F2937` text, `#F0F4FF` hover background
+
+### 3.2 Home (`home/home.component.css`)
+
+- **Hero section** replaces jumbotron:
+  - Gradient background: `linear-gradient(135deg, #5B7FFF 0%, #38C172 100%)`
+  - Rounded bottom edge: `border-radius: 0 0 40px 40px`
+  - White text, large heading (Rubik 700), subtitle in Rubik 400
+  - Padding: `80px 24px`
+- **Three-column cards** below hero:
+  - White background, `20px` radius, medium shadow
+  - Colored top border: card 1 = `#5B7FFF`, card 2 = `#38C172`, card 3 = `#FF8C42`
+  - Padding: `32px 24px`
+  - Text in `#1F2937`
+
+### 3.3 Login & Register (`login/login.component.css`, `register/register.component.css`)
+
+- Page background: `#F7F8FD`
+- Centered card: max-width `420px`, `20px` radius, strong shadow, white surface
+- Card padding: `48px 40px`
+- Heading: Rubik 600, `#1F2937`
+- Labels: Rubik 500, `#6B7280`, `12px` font-size
+- Inputs: `6px` radius, `#E5E7EB` border, `#5B7FFF` focus ring
+- Submit button: full-width, `12px` radius, primary blue, `46px` height
+- Link text: `#5B7FFF`
+
+### 3.4 Quiz — Questions (`vanhillequiz/questions/questions.component.css`)
+
+- Outer wrapper: `#F7F8FD` background, centered max-width `720px`
+- Question card: white, `20px` radius, medium shadow, `32px` padding
+- Question counter: Rubik 500, `#6B7280`, small caps
+- **Timer card**: `#FF8C42` background, white text, Rubik 700, `12px` radius
+- **Radio options**: each option is a full-width selectable card
+  - Default: white border `#E5E7EB`, `12px` radius
+  - Selected: `#EEF2FF` background, `#5B7FFF` border
+  - Hover: `#F7F8FD` background
+- Navigation buttons:
+  - Previous: outlined style (`#5B7FFF` border, transparent bg)
+  - Next / Finish: filled primary blue
+
+### 3.5 Reports (`vanhillequiz/report/`)
+
+- Section headings: Rubik 600, colored left-border `4px solid #5B7FFF`
+- Chart containers: white card, `20px` radius, medium shadow, `24px` padding
+- Data value labels: Rubik 500, `#1F2937`
+- Table cells: Rubik 400, `#1F2937`, subtle row hover `#F0F4FF`
+
+### 3.6 Cloud Links (`cloudlinks/cloudlinks.component.css`)
+
+- Page header: same gradient hero style as Home (shorter, `48px` padding)
+- Table rows: `#FFFFFF`, hover `#F0F4FF`
+- Edit button: small, `6px` radius, `#5B7FFF` background
+- Delete button: small, `6px` radius, `#EF4444` background
+- Add/Delete Table modal: `20px` radius, strong shadow, `32px` padding
+
+### 3.7 Pythagorean Tools (`pythagorean/`, `pythagorean-cutting/`)
+
+- Update surrounding UI chrome to match design system:
+  - Button styles → design system tokens
+  - Section backgrounds → `#F7F8FD`
+  - Task description cards → white, `12px` radius, medium shadow
+- Keep SVG interactive canvas untouched
+- Color palette for SVG shapes already uses friendly pastel tones — keep as-is
+
+---
+
+## 4. Implementation Plan (high-level)
+
+1. Add Rubik font import to `angular-src/src/index.html`
+2. Write CSS custom properties + Bootstrap 3 overrides in `angular-src/src/styles.css`
+3. Rewrite component CSS files in this order:
+   - `navbar`
+   - `home`
+   - `login` + `register`
+   - `vanhillequiz/questions`
+   - `vanhillequiz/report` (student + class)
+   - `cloudlinks`
+   - `pythagorean` + `pythagorean-cutting`
+4. Minor HTML template adjustments where CSS alone cannot achieve the design (e.g., hero section wrapper div, radio option card wrappers)
+
+---
+
+## 5. Constraints
+
+- Angular 5 and Bootstrap 3.3.7 versions are not changing
+- All RTL (`dir="rtl"`) behavior must be preserved
+- Hebrew text rendering must remain correct with Rubik
+- No new npm packages
+- Interactive SVG canvases in pythagorean components are not touched

--- a/server.js
+++ b/server.js
@@ -41,7 +41,9 @@ const cloudLinks = require('./routes/cloudlinks');
   
    //port number
    const port = process.env.PORT || 3050;
-   app.use(forceSSL());
+   if (process.env.NODE_ENV === 'production') {
+     app.use(forceSSL());
+   }
 
 //port number - for develop
 //const port = 3050;


### PR DESCRIPTION
## Summary

Full visual redesign of the site plus a number of functional fixes uncovered along the way.

**Design system**
- Full "friendly academic" restyle: navbar, sidebar, forms, buttons, panels, alerts, tables, dropdowns (see `styles.css`)
- Site-wide base font size increase (root `rem` scale)
- Removed Bootstrap's legacy glossy button skin (`bootstrap-theme.min.css`) that was fighting the new flat design
- Rebranded from the placeholder "Math"/"Qapp" to **זווית** (Angle), with real homepage copy replacing lorem ipsum
- Redesigned the login/register/profile pages with a consistent gradient-header card
- Redesigned the student-report date-range and student-ID search controls, including localizing the third-party calendar widget (Hebrew month/weekday names, corrected RTL nav-arrow direction)

**Layout/responsiveness fixes**
- Fixed sidebar not reserving space from page content (was rendering underneath it)
- Fixed CSS Grid overflow in the Pythagorean tool pages (`1fr` → `minmax(0, 1fr)`)
- Fixed sidebar `<li>` items being shrunk to text width by Bootstrap's horizontal-nav CSS instead of spanning full width
- Fixed mobile nav bar wrapping to two rows (login link pushed below the header)
- Fixed report pages broken by stray `col-*-pull-1` Bootstrap classes shifting content off-screen
- Removed inline `style="padding: 0"` that was canceling the sidebar-offset CSS

**Functional fixes**
- Added an app-wide HTTP error interceptor so failed API calls actually show a toast instead of failing silently (`.subscribe()` calls had no error handler anywhere in the app)
- Replaced `angular2-flash-messages` (a plain banner) with `ngx-toastr` for real floating toast notifications
- Added `proxy.conf.json` so `ng serve` correctly proxies API calls to the Express backend in local dev instead of 404ing against the dev server itself
- Gated `server.js`'s `forceSSL()` behind `NODE_ENV === 'production'` — it was redirecting every local request to a nonexistent HTTPS endpoint

## Test plan
- [x] `ng build` succeeds cleanly
- [x] Manually verified key pages (home, login, register, profile, cloudlinks, class/student reports, Pythagorean tools) via headless-browser screenshots at mobile/tablet/desktop widths, no horizontal overflow
- [x] Verified error and success toasts render correctly end-to-end against the real backend
- [ ] Recommend a manual pass through the site before merging, given the scope of changes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>